### PR TITLE
Add ルーティングの追加

### DIFF
--- a/components/layouts/Layout.tsx
+++ b/components/layouts/Layout.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+import type { ReactNode } from 'react';
+
+type Props = {
+  title: string;
+  children: ReactNode;
+};
+
+export default function Layout({ title, children }: Props) {
+  return (
+    <>
+      <Head>
+        <title>{title} | Gawdi Board</title>
+        <meta name="description" content="ECCコン専用の掲示板" />
+      </Head>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,16 @@
 import type { AppProps } from 'next/app';
+import type { NextPage } from 'next';
+import type { ReactElement, ReactNode } from 'react';
 import { setUpWorker } from '../mocks/browser';
 import { AppProvider } from '../contexts/AppProvider';
+
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
 
 if (process.env.NODE_ENV === 'development') {
   if (typeof window !== 'undefined') {
@@ -11,10 +21,12 @@ if (process.env.NODE_ENV === 'development') {
   }
 }
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
   return (
     <AppProvider>
-      <Component {...pageProps} />
+      {getLayout(<Component {...pageProps} />)}
       <style global jsx>
         {`
           *,

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../components/layouts/Layout';
+
+function AboutPage() {
+  return (
+    <div>
+      <h1>当サイトについて</h1>
+    </div>
+  );
+}
+
+AboutPage.getLayout = (page: ReactElement) => {
+  return <Layout title="当サイトについて">{page}</Layout>;
+};
+
+export default AboutPage;

--- a/pages/board/offers/[offerId].tsx
+++ b/pages/board/offers/[offerId].tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function OfferDetailPage() {
+  return (
+    <div>
+      <h1>募集詳細</h1>
+    </div>
+  );
+}
+
+OfferDetailPage.getLayout = (page: ReactElement) => {
+  return <Layout title="募集の詳細">{page}</Layout>;
+};
+
+export default OfferDetailPage;

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function AllOffersPage() {
+  return (
+    <div>
+      <h1>募集一覧</h1>
+    </div>
+  );
+}
+
+AllOffersPage.getLayout = (page: ReactElement) => {
+  return <Layout title="募集を探す">{page}</Layout>;
+};
+
+export default AllOffersPage;

--- a/pages/board/promotions/[promotionId].tsx
+++ b/pages/board/promotions/[promotionId].tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function PromotionDetailPage() {
+  return (
+    <div>
+      <h1>宣伝詳細</h1>
+    </div>
+  );
+}
+
+PromotionDetailPage.getLayout = (page: ReactElement) => {
+  return <Layout title="宣伝の詳細">{page}</Layout>;
+};
+
+export default PromotionDetailPage;

--- a/pages/board/promotions/index.tsx
+++ b/pages/board/promotions/index.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function AllPromotionsPage() {
+  return (
+    <div>
+      <h1>宣伝一覧</h1>
+    </div>
+  );
+}
+
+AllPromotionsPage.getLayout = (page: ReactElement) => {
+  return <Layout title="宣伝を探す">{page}</Layout>;
+};
+
+export default AllPromotionsPage;

--- a/pages/board/works/[workId].tsx
+++ b/pages/board/works/[workId].tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function WorkDetailPage() {
+  return (
+    <div>
+      <h1>作品詳細</h1>
+    </div>
+  );
+}
+
+WorkDetailPage.getLayout = (page: ReactElement) => {
+  return <Layout title="作品の詳細">{page}</Layout>;
+};
+
+export default WorkDetailPage;

--- a/pages/board/works/index.tsx
+++ b/pages/board/works/index.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function AllWorkPage() {
+  return (
+    <div>
+      <h1>作品一覧</h1>
+    </div>
+  );
+}
+
+AllWorkPage.getLayout = (page: ReactElement) => {
+  return <Layout title="作品を探す">{page}</Layout>;
+};
+
+export default AllWorkPage;

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../components/layouts/Layout';
+
+function ContactPage() {
+  return (
+    <div>
+      <h1>お問い合わせ</h1>
+    </div>
+  );
+}
+
+ContactPage.getLayout = (page: ReactElement) => {
+  return <Layout title="お問い合わせ">{page}</Layout>;
+};
+
+export default ContactPage;

--- a/pages/how-to-use.tsx
+++ b/pages/how-to-use.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../components/layouts/Layout';
+
+function HowToUsePage() {
+  return (
+    <div>
+      <h1>当サイトのサイト使い方</h1>
+    </div>
+  );
+}
+
+HowToUsePage.getLayout = (page: ReactElement) => {
+  return <Layout title="当サイトの使い方">{page}</Layout>;
+};
+
+export default HowToUsePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,10 @@
-import type { NextPage } from 'next';
-import Head from 'next/head';
+import type { ReactElement } from 'react';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup/dist/yup';
 import * as yup from 'yup';
+import Layout from '../components/layouts/Layout';
 import { jsonClient } from '../utils/httpClient';
 
 type FormValue = {
@@ -17,7 +17,7 @@ const schema = yup
   })
   .required();
 
-const Home: NextPage = () => {
+function HomePage() {
   const [keyword, setKeyword] = useState('');
   const { data, error, isLoading } = useQuery(
     'test',
@@ -43,25 +43,19 @@ const Home: NextPage = () => {
 
   return (
     <div>
-      <Head>
-        <title>Gawdi Board</title>
-        <meta name="description" content="ECCコン専用の掲示板" />
-      </Head>
-      <main>
-        <h1>Gawdi Boardへようこそ</h1>
-        <form onSubmit={onSubmit}>
-          <input {...register('keyword')}></input>
-          {errors.keyword && <span>{errors.keyword.message}</span>}
-          <button>押す</button>
-        </form>
-        {isLoading && <p>ロード中だよ...</p>}
-        {data && <p>{data.message}</p>}
-        {error && (
-          <p role="alert" className="error">
-            エラーが起こったよ
-          </p>
-        )}
-      </main>
+      <h1>Gawdi Boardへようこそ</h1>
+      <form onSubmit={onSubmit}>
+        <input {...register('keyword')}></input>
+        {errors.keyword && <span>{errors.keyword.message}</span>}
+        <button>押す</button>
+      </form>
+      {isLoading && <p>ロード中だよ...</p>}
+      {data && <p>{data.message}</p>}
+      {error && (
+        <p role="alert" className="error">
+          エラーが起こったよ
+        </p>
+      )}
       <footer>ここはフッターかもしれないよ</footer>
       <style jsx>{`
         h1 {
@@ -73,6 +67,10 @@ const Home: NextPage = () => {
       `}</style>
     </div>
   );
+}
+
+HomePage.getLayout = (page: ReactElement) => {
+  return <Layout title="ホーム">{page}</Layout>;
 };
 
-export default Home;
+export default HomePage;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../components/layouts/Layout';
+
+function LoginPage() {
+  return (
+    <div>
+      <h1>ログイン</h1>
+    </div>
+  );
+}
+
+LoginPage.getLayout = (page: ReactElement) => {
+  return <Layout title="ログイン">{page}</Layout>;
+};
+
+export default LoginPage;

--- a/pages/offer/edit/[offerId].tsx
+++ b/pages/offer/edit/[offerId].tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function EditOfferPage() {
+  return (
+    <div>
+      <h1>募集編集</h1>
+    </div>
+  );
+}
+
+EditOfferPage.getLayout = (page: ReactElement) => {
+  return <Layout title="募集を編集する">{page}</Layout>;
+};
+
+export default EditOfferPage;

--- a/pages/offer/post.tsx
+++ b/pages/offer/post.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../components/layouts/Layout';
+
+function PostOfferPage() {
+  return (
+    <div>
+      <h1>募集投稿</h1>
+    </div>
+  );
+}
+
+PostOfferPage.getLayout = (page: ReactElement) => {
+  return <Layout title="新しい募集を投稿する">{page}</Layout>;
+};
+
+export default PostOfferPage;

--- a/pages/promotion/edit/[promotionId].tsx
+++ b/pages/promotion/edit/[promotionId].tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function PostPromotionPage() {
+  return (
+    <div>
+      <h1>宣伝編集</h1>
+    </div>
+  );
+}
+
+PostPromotionPage.getLayout = (page: ReactElement) => {
+  return <Layout title="新しい宣伝を編集する">{page}</Layout>;
+};
+
+export default PostPromotionPage;

--- a/pages/promotion/post.tsx
+++ b/pages/promotion/post.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../components/layouts/Layout';
+
+function PostPromotionPage() {
+  return (
+    <div>
+      <h1>宣伝投稿</h1>
+    </div>
+  );
+}
+
+PostPromotionPage.getLayout = (page: ReactElement) => {
+  return <Layout title="新しい宣伝を投稿する">{page}</Layout>;
+};
+
+export default PostPromotionPage;

--- a/pages/register/email.tsx
+++ b/pages/register/email.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../components/layouts/Layout';
+
+function RegisterEmailPage() {
+  return (
+    <div>
+      <h1>メールアドレス登録</h1>
+    </div>
+  );
+}
+
+RegisterEmailPage.getLayout = (page: ReactElement) => {
+  return <Layout title="メールアドレスを登録する">{page}</Layout>;
+};
+
+export default RegisterEmailPage;

--- a/pages/register/profile.tsx
+++ b/pages/register/profile.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../components/layouts/Layout';
+
+function RegisterProfilePage() {
+  return (
+    <div>
+      <h1>ユーザー情報登録</h1>
+    </div>
+  );
+}
+
+RegisterProfilePage.getLayout = (page: ReactElement) => {
+  return <Layout title="ユーザー情報を登録する">{page}</Layout>;
+};
+
+export default RegisterProfilePage;

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../components/layouts/Layout';
+
+function UserProfilePage() {
+  return (
+    <div>
+      <h1>ユーザー詳細</h1>
+    </div>
+  );
+}
+
+UserProfilePage.getLayout = (page: ReactElement) => {
+  return <Layout title="ユーザーのプロフィール">{page}</Layout>;
+};
+
+export default UserProfilePage;

--- a/pages/user/edit/email.tsx
+++ b/pages/user/edit/email.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function EditEmailPage() {
+  return (
+    <div>
+      <h1>メールアドレス変更</h1>
+    </div>
+  );
+}
+
+EditEmailPage.getLayout = (page: ReactElement) => {
+  return <Layout title="メールアドレスを変更する">{page}</Layout>;
+};
+
+export default EditEmailPage;

--- a/pages/user/edit/profile.tsx
+++ b/pages/user/edit/profile.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function EditProfilePage() {
+  return (
+    <div>
+      <h1>ユーザー情報変更</h1>
+    </div>
+  );
+}
+
+EditProfilePage.getLayout = (page: ReactElement) => {
+  return <Layout title="ユーザー情報を変更する">{page}</Layout>;
+};
+
+export default EditProfilePage;

--- a/pages/work/edit/[workId].tsx
+++ b/pages/work/edit/[workId].tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../../components/layouts/Layout';
+
+function EditWorkPage() {
+  return (
+    <div>
+      <h1>作品編集</h1>
+    </div>
+  );
+}
+
+EditWorkPage.getLayout = (page: ReactElement) => {
+  return <Layout title="作品を編集する">{page}</Layout>;
+};
+
+export default EditWorkPage;

--- a/pages/work/post.tsx
+++ b/pages/work/post.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from 'react';
+import Layout from '../../components/layouts/Layout';
+
+function PostWorkPage() {
+  return (
+    <div>
+      <h1>作品投稿</h1>
+    </div>
+  );
+}
+
+PostWorkPage.getLayout = (page: ReactElement) => {
+  return <Layout title="新しい作品を投稿する">{page}</Layout>;
+};
+
+export default PostWorkPage;


### PR DESCRIPTION
## 概要
ページを作ってルーティング設定をしました。

## やったこと
- 現在仕様書に定義されている全てのページへのルーティングを追加しました。
- 全てのページで使う共通レイアウトであるLayoutコンポーネントを作りました。
- ページごとに微妙にレイアウトが違うと思うので[ここ](https://nextjs.org/docs/basic-features/layouts#per-page-layouts)を参考にLayoutを好きに拡張できるようにしました。