### PR TITLE
Add 募集取得APIを叩いて詳細ページを表示する

### DIFF
--- a/contexts/AppProvider.tsx
+++ b/contexts/AppProvider.tsx
@@ -6,6 +6,8 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       retry: 1,
+      staleTime: 1000 * 30,
+      cacheTime: 1000 * 60 * 2,
     },
   },
 });

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from 'react-query';
+import { useQueryClient, useInfiniteQuery, useQuery } from 'react-query';
 import { jsonClient } from '../../utils/httpClient';
 import type { Tag } from './tags';
 import type { PaginatedResponse } from './typeUtils';
@@ -31,6 +31,7 @@ type GetOfferResponse = {
 };
 
 function useInfiniteOffers(options?: GetOffersRequest) {
+  const queryClient = useQueryClient();
   return useInfiniteQuery<GetOffersResponse, Error>(
     'offers',
     ({ pageParam }) => {
@@ -43,6 +44,17 @@ function useInfiniteOffers(options?: GetOffersRequest) {
       getNextPageParam: (lastPage) => {
         const nextPage = lastPage.meta.current_page + 1;
         return lastPage.meta.last_page >= nextPage ? nextPage : false;
+      },
+      onSuccess: (data) => {
+        data.pages[data.pages.length - 1].offers.forEach((offer) => {
+          queryClient.setQueryData(['offer', '' + offer.id], { offer });
+        });
+        // 募集の一件取得APIを叩いたときに再利用できるようにそれぞれキャッシュする
+        // offer_tag_idsなどのパラメタがあるのでgetQueryDataではどのクエリキャッシュから取ればいいかわからない
+        // この方法だとキーが個々のofferのcacheTimeはデフォルトで固定になるっぽいのと
+        // その他のクエリのオプションも設定できないけど、今のところ困らなさそうなのでこの方法を採用してる
+        // https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydata
+        // 問題が出てきたらキャッシュを諦めるか、直近の募集一覧APIコールのパラメタをどこかに覚えさせて対応してください
       },
     }
   );

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery, useQuery } from 'react-query';
 import { jsonClient } from '../../utils/httpClient';
 import type { Tag } from './tags';
 import type { PaginatedResponse } from './typeUtils';
@@ -23,8 +23,12 @@ type GetOffersRequest = {
   offer_tag_ids?: string[];
   page?: string;
 };
-
 type GetOffersResponse = PaginatedResponse<{ offers: Offer[] }>;
+
+type GetOfferRequest = string;
+type GetOfferResponse = {
+  offer: Offer;
+};
 
 function useInfiniteOffers(options?: GetOffersRequest) {
   return useInfiniteQuery<GetOffersResponse, Error>(
@@ -44,5 +48,18 @@ function useInfiniteOffers(options?: GetOffersRequest) {
   );
 }
 
+function useOffer(offer_id: GetOfferRequest, enabled = true) {
+  return useQuery<GetOfferResponse>(
+    ['offer', offer_id],
+    () =>
+      jsonClient('/offer/single', {
+        params: { offer_id },
+      }),
+    {
+      enabled,
+    }
+  );
+}
+
 export type { Offer };
-export { useInfiniteOffers };
+export { useInfiniteOffers, useOffer };

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -20,7 +20,7 @@ type Offer = {
 };
 
 type GetOffersRequest = {
-  offer_tag_ids?: string[];
+  offer_tag_ids?: number[];
   page?: string;
 };
 type GetOffersResponse = PaginatedResponse<{ offers: Offer[] }>;
@@ -30,12 +30,12 @@ type GetOfferResponse = {
   offer: Offer;
 };
 
-function useInfiniteOffers(options?: GetOffersRequest) {
+function useInfiniteOffers(options: GetOffersRequest = {}) {
   const queryClient = useQueryClient();
   return useInfiniteQuery<GetOffersResponse, Error>(
     'offers',
     ({ pageParam }) => {
-      pageParam || (pageParam = options?.page || 1);
+      pageParam || (pageParam = options.page || 1);
       return jsonClient('/offer/list', {
         params: { ...options, page: pageParam },
       });

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -25,7 +25,7 @@ type GetOffersRequest = {
 };
 type GetOffersResponse = PaginatedResponse<{ offers: Offer[] }>;
 
-type GetOfferRequest = string;
+type GetOfferRequest = { offer_id: number };
 type GetOfferResponse = {
   offer: Offer;
 };
@@ -47,7 +47,7 @@ function useInfiniteOffers(options?: GetOffersRequest) {
       },
       onSuccess: (data) => {
         data.pages[data.pages.length - 1].offers.forEach((offer) => {
-          queryClient.setQueryData(['offer', '' + offer.id], { offer });
+          queryClient.setQueryData(['offer', offer.id], { offer });
         });
         // 募集の一件取得APIを叩いたときに再利用できるようにそれぞれキャッシュする
         // offer_tag_idsなどのパラメタがあるのでgetQueryDataではどのクエリキャッシュから取ればいいかわからない
@@ -60,12 +60,12 @@ function useInfiniteOffers(options?: GetOffersRequest) {
   );
 }
 
-function useOffer(offer_id: GetOfferRequest, enabled = true) {
+function useOffer({ offer_id }: GetOfferRequest, enabled = true) {
   return useQuery<GetOfferResponse>(
     ['offer', offer_id],
     () =>
       jsonClient('/offer/single', {
-        params: { offer_id },
+        params: { offer_id: offer_id.toString() },
       }),
     {
       enabled,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,12 @@
       "name": "gawdi-board-frontend",
       "dependencies": {
         "@hookform/resolvers": "^2.8.4",
+        "@types/react-modal": "^3.13.1",
         "next": "^12.0.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-hook-form": "^7.20.5",
+        "react-modal": "^3.14.4",
         "react-query": "3.33.7",
         "yup": "^0.32.11"
       },
@@ -1997,14 +1999,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/react": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.35.tgz",
       "integrity": "sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2016,6 +2016,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
+      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -2032,8 +2040,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.1",
@@ -3471,8 +3478,7 @@
     "node_modules/csstype": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-      "dev": true
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.7",
@@ -4640,6 +4646,11 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "node_modules/exit": {
       "version": "0.1.2",
@@ -8419,7 +8430,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8429,8 +8439,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-expr": {
       "version": "2.0.4",
@@ -8607,6 +8616,29 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-modal": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.4.tgz",
+      "integrity": "sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
+      }
     },
     "node_modules/react-query": {
       "version": "3.33.7",
@@ -9911,6 +9943,14 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -11747,14 +11787,12 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.35.tgz",
       "integrity": "sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11766,6 +11804,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-modal": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
+      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
       "requires": {
         "@types/react": "*"
       }
@@ -11782,8 +11828,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/set-cookie-parser": {
       "version": "2.4.1",
@@ -12892,8 +12937,7 @@
     "csstype": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-      "dev": true
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
     "damerau-levenshtein": {
       "version": "1.0.7",
@@ -13766,6 +13810,11 @@
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       }
+    },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exit": {
       "version": "0.1.2",
@@ -16606,7 +16655,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -16616,8 +16664,7 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -16752,6 +16799,22 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.4.tgz",
+      "integrity": "sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      }
     },
     "react-query": {
       "version": "3.33.7",
@@ -17751,6 +17814,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^2.8.4",
+    "@types/react-modal": "^3.13.1",
     "next": "^12.0.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.20.5",
+    "react-modal": "^3.14.4",
     "react-query": "3.33.7",
     "yup": "^0.32.11"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import type { ReactElement, ReactNode } from 'react';
+import Modal from 'react-modal';
 import { AppProvider } from '../contexts/AppProvider';
 import { setUpWorker } from '../mocks/browser';
 
@@ -20,6 +21,8 @@ if (process.env.NODE_ENV === 'development') {
     setUpWorker().start({ onUnhandledRequest: 'bypass' });
   }
 }
+
+Modal.setAppElement('#__next');
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page);

--- a/pages/board/offers/[offerId].tsx
+++ b/pages/board/offers/[offerId].tsx
@@ -35,9 +35,12 @@ function OfferDetailPage() {
   const router = useRouter();
 
   const { data, error, isLoading } = useOffer(
-    // 実際にはstring[]は入らないのでstringに変換する
-    '' + router.query.offerId,
-    // 初期ロードでrouter.queryが空オブジェクトになるのでリクエストをスキップ
+    // 初期ロード時にrouter.queryが空オブジェクトになる
+    // 参考: https://nextjs.org/docs/routing/dynamic-routes#caveats
+    // offer_idがundefinedの内はリクエストを送らないのでそのまま通す。
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    { offer_id: +router.query.offerId! },
+    // offer_idが取れるまでリクエストを遅らせる
     router.isReady
   );
 

--- a/pages/board/offers/[offerId].tsx
+++ b/pages/board/offers/[offerId].tsx
@@ -1,9 +1,37 @@
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
+import Modal from 'react-modal';
+import css from 'styled-jsx/css';
 import Layout from '../../../components/layouts/Layout';
 import { useOffer } from '../../../hooks/requests/offers';
 
+const { className: modalClassName, styles: modalStyles } = css.resolve`
+  .modal {
+    position: absolute;
+    top: 30%;
+    right: 30%;
+    bottom: 30%;
+    left: 30%;
+    /* min-width: 450px; */
+    padding: 20px;
+    border: 1px solid gray;
+    border-radius: 12px;
+    background-color: white;
+  }
+
+  @media (max-width: 768px) {
+    .modal {
+      top: 25%;
+      right: 20px;
+      bottom: 25%;
+      left: 20px;
+    }
+  }
+`;
+
 function OfferDetailPage() {
+  const [showModal, setShowModal] = useState(false);
   const router = useRouter();
 
   const { data, error, isLoading } = useOffer(
@@ -51,13 +79,22 @@ function OfferDetailPage() {
           </p>
           <p>投稿日: {offer.post_date}</p>
           <p>掲載終了日: {offer.end_date}</p>
-          <button
-            onClick={() => {
-              alert('興味がある');
-            }}
+          <button onClick={() => setShowModal(true)}>興味がある</button>
+          <Modal
+            className={`modal ${modalClassName}`}
+            isOpen={showModal}
+            onRequestClose={() => setShowModal(false)}
           >
-            興味がある
-          </button>
+            <div className="modal-header">
+              <button onClick={() => setShowModal(false)}>X</button>
+            </div>
+            <button>ぜひ参加したい</button>
+            <br />
+            <button>内容によっては参加したい</button>
+            <br />
+            <button>とりあえず話してみたい</button>
+            <br />
+          </Modal>
         </div>
       )}
       <style jsx>
@@ -69,11 +106,19 @@ function OfferDetailPage() {
           .offerer {
             margin-bottom: 8px;
           }
+          .modal-header {
+            display: flex;
+            flex-direction: row-reverse;
+          }
+          button {
+            margin-bottom: 8px;
+          }
           p {
             margin-bottom: 8px;
           }
         `}
       </style>
+      {modalStyles}
     </div>
   );
 }

--- a/pages/board/offers/[offerId].tsx
+++ b/pages/board/offers/[offerId].tsx
@@ -1,10 +1,79 @@
+import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../../components/layouts/Layout';
+import { useOffer } from '../../../hooks/requests/offers';
 
 function OfferDetailPage() {
+  const router = useRouter();
+
+  const { data, error, isLoading } = useOffer(
+    // 実際にはstring[]は入らないのでstringに変換する
+    '' + router.query.offerId,
+    // 初期ロードでrouter.queryが空オブジェクトになるのでリクエストをスキップ
+    router.isReady
+  );
+
+  const offer = data?.offer;
   return (
     <div>
-      <h1>募集詳細</h1>
+      {isLoading && <p>ロード中</p>}
+      {error && <p role="alert">エラーが発生しました。詳細: error.message</p>}
+      {offer && (
+        <div className="offer">
+          <h1>{offer.title}</h1>
+          <div className="tags">
+            {offer.tags.map((tag) => (
+              <span key={tag.id} className="tag">
+                #{tag.name}
+              </span>
+            ))}
+          </div>
+          <div className="offerer">
+            募集主の情報:
+            <br />
+            {offer.user_name} {offer.user_class} {offer.student_number}
+          </div>
+          <p>募集対象者: {offer.target || '明記なし'}</p>
+          <p>役職と人数: {offer.job || '明記なし'}</p>
+          <p>備考: {offer.note || ''}</p>
+          {offer.picture && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={offer.picture}
+              alt="投稿主がアップロードした画像"
+              width="300"
+              height="200"
+            />
+          )}
+          <p>
+            参考リンク:{' '}
+            {offer.link ? <a href={offer.link}>{offer.link}</a> : 'なし'}
+          </p>
+          <p>投稿日: {offer.post_date}</p>
+          <p>掲載終了日: {offer.end_date}</p>
+          <button
+            onClick={() => {
+              alert('興味がある');
+            }}
+          >
+            興味がある
+          </button>
+        </div>
+      )}
+      <style jsx>
+        {`
+          .tag {
+            background-color: lightgray;
+            margin: 0 4px;
+          }
+          .offerer {
+            margin-bottom: 8px;
+          }
+          p {
+            margin-bottom: 8px;
+          }
+        `}
+      </style>
     </div>
   );
 }

--- a/utils/__tests__/httpClient.test.ts
+++ b/utils/__tests__/httpClient.test.ts
@@ -51,4 +51,21 @@ describe('jsonClient', () => {
       jsonClient('/success', { body: { a: 1 }, method: 'POST' })
     ).resolves.toHaveProperty('contentType', 'application/json');
   });
+
+  it('クエリパラメタはnumber型でも動く', async () => {
+    server.use(
+      rest.get('/success', async (req, res, ctx) => {
+        const queryParameter = req.url.searchParams.toString();
+        return res(ctx.status(200), ctx.json({ queryParameter }));
+      })
+    );
+
+    await expect(
+      jsonClient('/success', { params: { a: 1 } })
+    ).resolves.toHaveProperty('queryParameter', 'a=1');
+
+    await expect(
+      jsonClient('/success', { params: { a: [1, 2, 3] } })
+    ).resolves.toHaveProperty('queryParameter', encodeURI('a[]=1&a[]=2&a[]=3'));
+  });
 });

--- a/utils/httpClient.ts
+++ b/utils/httpClient.ts
@@ -1,13 +1,13 @@
-function buildURLSeachParams(params: Record<string, string | string[]>) {
+function buildURLSeachParams(params: Record<string, any>) {
   // クエリパラメタが配列の時だけ処理を分ける
   const stringParams: Record<string, string> = {};
   const arrayParams: Record<string, string[]> = {};
 
   Object.keys(params).forEach((key) => {
     if (Array.isArray(params[key])) {
-      arrayParams[key] = params[key] as string[];
+      arrayParams[key] = params[key].map((param: any) => param.toString());
     } else {
-      stringParams[key] = params[key] as string;
+      stringParams[key] = params[key].toString();
     }
   });
 
@@ -24,8 +24,8 @@ function buildURLSeachParams(params: Record<string, string | string[]>) {
 }
 
 type jsonClientData = {
-  // クエリパラメタ (stringのみ https://github.com/microsoft/TypeScript/issues/32951)
-  params?: Record<string, string | string[]>;
+  // クエリパラメタ (string以外も受け付けてtoStringする)
+  params?: Record<string, any>;
   //リクエストボディ
   body?: any;
   method?: string;


### PR DESCRIPTION
## 概要
募集詳細ページの骨組みを作りました。

## メモ
応募モーダルはまだ作っていませんが、モーダルの表示のために[react-modal](http://reactcommunity.org/react-modal/)を入れました。
URLSearchParamsのTSの型の型定義に合わせてoffer_idやoffer_tag_idsを文字列型として定義していたのですが、アプリの要件とあってないのであまり良くないと思い数字型に変更しました。クエリフックの中で毎回キャストするのも大変だと思ったので、jsonClientの型定義を変更して、クエリパラメタに文字列以外も入れられるようにしました。