### PR TITLE
Add 募集の投稿と編集をする画面と機能

### DIFF
--- a/components/OfferForm.tsx
+++ b/components/OfferForm.tsx
@@ -124,7 +124,9 @@ function OfferForm({
               </Fragment>
             ))}
         </Modal>
-        <button onClick={() => setShowTagSelector(true)}>タグ一覧</button>
+        <button type="button" onClick={() => setShowTagSelector(true)}>
+          タグ一覧
+        </button>
         {tags && (
           <div>
             {tags.tags

--- a/components/OfferForm.tsx
+++ b/components/OfferForm.tsx
@@ -1,0 +1,196 @@
+import { yupResolver } from '@hookform/resolvers/yup/dist/yup';
+import { useRouter } from 'next/router';
+import { Fragment, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useForm } from 'react-hook-form';
+import type {
+  DefaultValues,
+  NestedValue,
+  Resolver,
+  SubmitHandler,
+} from 'react-hook-form';
+import Modal from 'react-modal';
+import * as yup from 'yup';
+import { useTags } from '../hooks/requests/tags';
+
+type FormValue = {
+  title: string;
+  target: string;
+  job: string;
+  note: string;
+  picture: string;
+  link: string;
+  end_date: string;
+  user_class: string;
+  offer_tag_ids: NestedValue<number[]>;
+};
+
+type DefaultFormValues = DefaultValues<FormValue>;
+
+type Props = {
+  onSubmit: SubmitHandler<FormValue>;
+  defaultFormValues?: DefaultFormValues;
+  submitButton: (utils: { submit: () => void }) => ReactNode; // TODO: デフォルトのボタンを追加する
+  cancelButton: (utils: { handleCancel: () => void }) => ReactNode;
+};
+
+const schema = yup.object({
+  title: yup.string().required('タイトルは入力が必須です'),
+  target: yup.string(),
+  job: yup.string(),
+  note: yup.string(),
+  picture: yup.string(), //TODO: stringじゃない気がする
+  link: yup.string().url('リンクは有効なURLでなければいけません'),
+  // 投稿内容の入力中に日付を跨いだ場合を考慮してバリデーションのたびに現在日付を取得する
+  end_date: yup.lazy(() => {
+    const today = new Date(new Date().setHours(0, 0, 0, 0)).getTime();
+    const dayInMs = 1000 * 60 * 60 * 24;
+    const min = new Date(today + dayInMs * 1);
+    const max = new Date(today + dayInMs * 90);
+
+    return yup
+      .date()
+      .required('掲載終了日は選択が必須です')
+      .min(min, '掲載終了日は明日以降でなければいけません')
+      .max(max, '掲載終了日は今から90日以内でなければいけません')
+      .nullable()
+      .transform((current, original) => (original === '' ? null : current));
+  }),
+  user_class: yup.string().required('募集主のクラスは入力が必須です'),
+  offer_tag_ids: yup
+    .array(yup.number())
+    .min(1, 'タグは1つ以上選ぶ必要があります')
+    .transform((value) => value.filter(Boolean)),
+});
+
+function OfferForm({
+  onSubmit,
+  defaultFormValues = {},
+  submitButton,
+  cancelButton,
+}: Props) {
+  const [showTagSelector, setShowTagSelector] = useState(false);
+  const router = useRouter();
+
+  const { data: tags } = useTags({ tag_genre_id: 1 });
+
+  const { register, handleSubmit, formState, watch } = useForm<FormValue>({
+    resolver: yupResolver(schema) as Resolver<FormValue>,
+    defaultValues: Object.assign<DefaultFormValues, DefaultFormValues>(
+      { offer_tag_ids: [] },
+      defaultFormValues
+    ),
+  });
+  const formErrors = formState.errors;
+  const selectedTags = watch('offer_tag_ids')
+    .filter(Boolean)
+    .map((id) => +id);
+
+  const submit = () => {
+    handleSubmit(onSubmit)();
+  };
+  const handleCancel = () => {
+    if (confirm('入力内容を破棄しますか?')) {
+      router.push('/board/offers/');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <p>募集主: 2180372 ECC太郎</p>
+      <div>
+        <label htmlFor="title">募集のタイトル</label>
+        <input id="title" type="input" {...register('title')} />
+        {formErrors.title && <span>{formErrors.title.message}</span>}
+      </div>
+      <div className="tags">
+        タグ
+        <Modal
+          isOpen={showTagSelector}
+          onRequestClose={() => setShowTagSelector(false)}
+        >
+          <button onClick={() => setShowTagSelector(false)}>x</button>
+          {tags &&
+            tags.tags.map((tag, i) => (
+              <Fragment key={tag.id}>
+                <label htmlFor={`tag${i}`}>{tag.name}</label>
+                <input
+                  id={`tag${i}`}
+                  type="checkbox"
+                  value={tag.id}
+                  {...register(`offer_tag_ids.${i}`)}
+                />
+                <br />
+              </Fragment>
+            ))}
+        </Modal>
+        <button onClick={() => setShowTagSelector(true)}>タグ一覧</button>
+        {tags && (
+          <div>
+            {tags.tags
+              .filter(({ id }) => selectedTags.includes(id))
+              .map((tag) => (
+                <span key={tag.id} className="tag">
+                  #{tag.name}
+                </span>
+              ))}
+          </div>
+        )}
+        {formErrors.offer_tag_ids && (
+          <span>{formErrors.offer_tag_ids.message}</span>
+        )}
+      </div>
+      <div>
+        <label htmlFor="end-date">掲載終了日</label>
+        <input id="end-date" type="date" {...register('end_date')} />
+        {formErrors.end_date && <span>{formErrors.end_date.message}</span>}
+      </div>
+      <div>
+        <label htmlFor="target">役職ごとの募集人数</label>
+        <textarea id="target" {...register('target')} />
+        {formErrors.target && <span>{formErrors.target.message}</span>}
+      </div>
+      <div>
+        <label htmlFor="note">備考</label>
+        <textarea id="note" {...register('note')} />
+        {formErrors.note && <span>{formErrors.note.message}</span>}
+      </div>
+      <div>
+        <label htmlFor="picture">参考画像</label>
+        <input id="picture" type="file" {...register('picture')} />
+        {formErrors.picture && <span>{formErrors.picture.message}</span>}
+      </div>
+      <div>
+        <label htmlFor="user_class">募集主のクラス</label>
+        <input id="user-class" type="text" {...register('user_class')} />
+        {formErrors.user_class && <span>{formErrors.user_class.message}</span>}
+      </div>
+      <div>
+        <label htmlFor="link">参考リンク</label>
+        <input id="link" type="text" {...register('link')} />
+        {formErrors.link && <span>{formErrors.link.message}</span>}
+      </div>
+      {submitButton({ submit })}
+      {cancelButton({ handleCancel })}
+      <style jsx>
+        {`
+          div:not(first-child) {
+            margin: 16px;
+          }
+          label {
+            vertical-align: top;
+            margin-right: 8px;
+          }
+          .tag {
+            margin: 4px;
+            padding: 4px;
+            background-color: lightgray;
+            white-space: nowrap;
+          }
+        `}
+      </style>
+    </form>
+  );
+}
+
+export default OfferForm;

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -50,6 +50,13 @@ type AddOfferResponse = {
   offer: Offer;
 };
 
+type EditOfferRequest = {
+  offer_id: number;
+} & Partial<AddOfferRequest>;
+type EditOfferResponse = {
+  offer: Offer;
+};
+
 function useInfiniteOffers(options: GetOffersRequest = {}) {
   const queryClient = useQueryClient();
   return useInfiniteQuery<GetOffersResponse, Error>(
@@ -111,5 +118,24 @@ function useAddOffer() {
   );
 }
 
+function useEditOffer() {
+  const queryClient = useQueryClient();
+  return useMutation<EditOfferResponse, Error, EditOfferRequest>(
+    (newOffer) => {
+      return jsonClient('/mock/offer/edit', {
+        method: 'POST',
+        body: { ...newOffer },
+      });
+    },
+    {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries('offers');
+        queryClient.setQueryData(['offer', data.offer.id], data);
+        alert('successfully edited offer!');
+      },
+    }
+  );
+}
+
 export type { Offer };
-export { useAddOffer, useInfiniteOffers, useOffer };
+export { useAddOffer, useEditOffer, useInfiniteOffers, useOffer };

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -94,6 +94,7 @@ function useOffer({ offer_id }: GetOfferRequest, enabled = true) {
 }
 
 function useAddOffer() {
+  const queryClient = useQueryClient();
   return useMutation<AddOfferResponse, Error, AddOfferRequest>(
     (newOffer) => {
       return jsonClient('/mock/offer/post', {
@@ -103,6 +104,7 @@ function useAddOffer() {
     },
     {
       onSuccess: () => {
+        queryClient.invalidateQueries('offers');
         alert('successfully posted offer!');
       },
     }

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery, useMutation } from 'react-query';
 import { jsonClient } from '../../utils/httpClient';
 import type { Tag } from './tags';
 import type { PaginatedResponse } from './typeUtils';
@@ -26,6 +26,21 @@ type GetOffersRequest = {
 
 type GetOffersResponse = PaginatedResponse<{ offers: Offer[] }>;
 
+type AddOfferRequest = {
+  title: string;
+  target: string;
+  job: string;
+  note?: string;
+  picture?: string;
+  link?: string;
+  end_date: string;
+  user_class: string;
+  offer_tag_ids?: number[];
+};
+type AddOfferResponse = {
+  offer: Offer;
+};
+
 function useInfiniteOffers(options?: GetOffersRequest) {
   return useInfiniteQuery<GetOffersResponse, Error>(
     'offers',
@@ -44,5 +59,21 @@ function useInfiniteOffers(options?: GetOffersRequest) {
   );
 }
 
+function useAddOffer() {
+  return useMutation<AddOfferResponse, Error, AddOfferRequest>(
+    (newOffer) => {
+      return jsonClient('/mock/offer/post', {
+        method: 'POST',
+        body: { ...newOffer },
+      });
+    },
+    {
+      onSuccess: () => {
+        alert('successfully posted offer!');
+      },
+    }
+  );
+}
+
 export type { Offer };
-export { useInfiniteOffers };
+export { useAddOffer, useInfiniteOffers };

--- a/hooks/requests/tags.ts
+++ b/hooks/requests/tags.ts
@@ -1,3 +1,6 @@
+import { useQuery } from 'react-query';
+import { jsonClient } from '../../utils/httpClient';
+
 type Tag = {
   id: number;
   name: string;
@@ -7,4 +10,28 @@ type Tag = {
   target_name?: string;
 };
 
+type GetTagsRequest = {
+  tag_genre_id: string;
+};
+type GetTagsResponse = {
+  tags: Tag[];
+};
+
+function useTags({ tag_genre_id }: GetTagsRequest) {
+  return useQuery<GetTagsResponse>(
+    ['tags', { tag_genre_id }],
+    () =>
+      jsonClient('/tag-list', {
+        params: {
+          tag_genre_id,
+        },
+      }),
+    {
+      staleTime: Infinity,
+      cacheTime: Infinity,
+    }
+  );
+}
+
+export { useTags };
 export type { Tag };

--- a/hooks/requests/tags.ts
+++ b/hooks/requests/tags.ts
@@ -11,7 +11,7 @@ type Tag = {
 };
 
 type GetTagsRequest = {
-  tag_genre_id: string;
+  tag_genre_id: number;
 };
 type GetTagsResponse = {
   tags: Tag[];

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -1,5 +1,6 @@
 import { rest } from 'msw';
 import { authHandlers } from './auth';
+import { constantsHandlers } from './constants';
 import { offersHandlers } from './offers';
 import { profileHandlers } from './profile';
 import { promotionsHandlers } from './promotions';
@@ -7,6 +8,7 @@ import { worksHandlers } from './works';
 
 export const handlers = [
   ...authHandlers,
+  ...constantsHandlers,
   ...offersHandlers,
   ...profileHandlers,
   ...promotionsHandlers,

--- a/mocks/handlers/offers.ts
+++ b/mocks/handlers/offers.ts
@@ -28,7 +28,7 @@ export const offersHandlers = [
       })
     );
   }),
-  rest.post('offer/post', (req, res, ctx) => {
+  rest.post('/mock/offer/post', (req, res, ctx) => {
     return res(
       ctx.status(201),
       ctx.json({

--- a/mocks/handlers/offers.ts
+++ b/mocks/handlers/offers.ts
@@ -39,7 +39,7 @@ export const offersHandlers = [
   rest.post('offer/delete', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
   }),
-  rest.post('offer/edit', (req, res, ctx) => {
+  rest.post('/mock/offer/edit', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { ReactElement } from 'react';
 import { Fragment } from 'react';
 import Layout from '../../../components/layouts/Layout';
@@ -17,6 +18,9 @@ function AllOffersPage() {
   return (
     <div>
       <h1>募集一覧</h1>
+      <div>
+        <Link href="/offer/post">投稿する</Link>
+      </div>
       {error && <p role="alert">エラーが発生しました。詳細: error.message</p>}
       {data && (
         <div className="offers-container">

--- a/pages/offer/edit/[offerId].tsx
+++ b/pages/offer/edit/[offerId].tsx
@@ -1,10 +1,72 @@
-import type { ReactElement } from 'react';
+import { useRouter } from 'next/router';
+import { ReactElement } from 'react';
 import Layout from '../../../components/layouts/Layout';
+import OfferForm from '../../../components/OfferForm';
+import { useEditOffer, useOffer } from '../../../hooks/requests/offers';
 
 function EditOfferPage() {
+  const {
+    mutate,
+    error: mutateOfferError,
+    isLoading: isMutatingOffer,
+  } = useEditOffer();
+
+  const router = useRouter();
+  const offerId = router.query.offerId as string;
+
+  const {
+    data,
+    error: getOfferError,
+    isLoading: isLoadingOffer,
+  } = useOffer({ offer_id: +offerId }, router.isReady);
+
+  const defaultFormValues = data && {
+    ...data.offer,
+    offer_tag_ids: data.offer.tags.map((tag) => tag.id),
+  };
+
   return (
     <div>
       <h1>募集編集</h1>
+      {isLoadingOffer && <p>データをロード中</p>}
+      {data && (
+        <>
+          <OfferForm
+            onSubmit={(newOfferAttributes) => {
+              const newOffer = Object.assign(newOfferAttributes, {
+                offer_id: +offerId,
+              });
+
+              mutate(newOffer, {
+                onSuccess: () => {
+                  router.push('/board/offers');
+                },
+              });
+            }}
+            defaultFormValues={defaultFormValues}
+            submitButton={() => (
+              <button disabled={!router.isReady || isMutatingOffer}>
+                編集
+              </button>
+            )}
+            cancelButton={({ handleCancel }) => (
+              <button
+                type="button"
+                onClick={handleCancel}
+                disabled={isMutatingOffer}
+              >
+                キャンセル
+              </button>
+            )}
+          />
+          {mutateOfferError && (
+            <p role="alert">
+              編集中にエラーが発生しました。詳細: {mutateOfferError.message}
+            </p>
+          )}
+        </>
+      )}
+      {getOfferError && <p role="alert">データの読み込みに失敗しました</p>}
     </div>
   );
 }

--- a/pages/offer/post.tsx
+++ b/pages/offer/post.tsx
@@ -1,10 +1,157 @@
+import { yupResolver } from '@hookform/resolvers/yup/dist/yup';
+import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import type { NestedValue, Resolver } from 'react-hook-form';
+import * as yup from 'yup';
 import Layout from '../../components/layouts/Layout';
+import { useAddOffer } from '../../hooks/requests/offers';
+
+type FormValue = {
+  title: string;
+  target: string;
+  job: string;
+  note: string;
+  picture: string;
+  link: string;
+  end_date: string;
+  user_class: string;
+  offer_tag_ids: NestedValue<number[]>;
+};
+
+const schema = yup.object({
+  title: yup.string().required('タイトルは入力が必須です'),
+  target: yup.string(),
+  job: yup.string(),
+  note: yup.string(),
+  picture: yup.string(), //TODO: stringじゃない気がする
+  link: yup.string().url('リンクは有効なURLでなければいけません'),
+  end_date: yup
+    .date()
+    .required('掲載終了日は選択が必須です')
+    .nullable()
+    .transform((current, original) => (original === '' ? null : current)),
+  user_class: yup.string().required('募集主のクラスは入力が必須です'),
+  offer_tag_ids: yup
+    .array(yup.number())
+    .min(1, 'タグは1つ以上選ぶ必要があります')
+    .transform((value) => value.filter(Boolean)),
+});
 
 function PostOfferPage() {
+  const { mutate, error, isLoading } = useAddOffer();
+
+  const { register, handleSubmit, formState } = useForm<FormValue>({
+    resolver: yupResolver(schema) as Resolver<FormValue>,
+  });
+  const onSubmit = handleSubmit((newOfferAttributes) => {
+    mutate(newOfferAttributes);
+  });
+  const formErrors = formState.errors;
+
+  const router = useRouter();
+
   return (
     <div>
       <h1>募集投稿</h1>
+      <form onSubmit={onSubmit}>
+        <p>募集主: 2180372 ECC太郎</p>
+        <div>
+          <label htmlFor="title">募集のタイトル</label>
+          <input id="title" type="input" {...register('title')} />
+          {formErrors.title && <span>{formErrors.title.message}</span>}
+        </div>
+        <div className="tags">
+          タグ
+          <br />
+          <label htmlFor="tag1">フロントエンジニア募集</label>
+          <input
+            id="tag1"
+            type="checkbox"
+            value={1}
+            {...register('offer_tag_ids.1')}
+          />
+          <br />
+          <label htmlFor="tag2">バックエンドエンジニア募集</label>
+          <input
+            id="tag2"
+            type="checkbox"
+            value={2}
+            {...register('offer_tag_ids.2')}
+          />
+          <br />
+          <label htmlFor="tag3">デザインナー募集</label>
+          <input
+            id="tag3"
+            type="checkbox"
+            value={3}
+            {...register('offer_tag_ids.3')}
+          />
+          {formErrors.offer_tag_ids && (
+            <span>{formErrors.offer_tag_ids.message}</span>
+          )}
+        </div>
+        <div>
+          <label htmlFor="end-date">掲載終了日</label>
+          <input id="end-date" type="date" {...register('end_date')} />
+          {formErrors.end_date && <span>{formErrors.end_date.message}</span>}
+        </div>
+        <div>
+          <label htmlFor="target">役職ごとの募集人数</label>
+          <textarea id="target" {...register('target')} />
+          {formErrors.target && <span>{formErrors.target.message}</span>}
+        </div>
+        <div>
+          <label htmlFor="note">備考</label>
+          <textarea id="note" {...register('note')} />
+          {formErrors.note && <span>{formErrors.note.message}</span>}
+        </div>
+        <div>
+          <label htmlFor="picture">参考画像</label>
+          <input id="picture" type="file" {...register('picture')} />
+          {formErrors.picture && <span>{formErrors.picture.message}</span>}
+        </div>
+        <div>
+          <label htmlFor="user_class">募集主のクラス</label>
+          <input id="user-class" type="text" {...register('user_class')} />
+          {formErrors.user_class && (
+            <span>{formErrors.user_class.message}</span>
+          )}
+        </div>
+        <div>
+          <label htmlFor="link">参考リンク</label>
+          <input id="link" type="text" {...register('link')} />
+          {formErrors.link && <span>{formErrors.link.message}</span>}
+        </div>
+        <button disabled={isLoading}>投稿</button>
+        <button
+          type="button"
+          onClick={() => {
+            if (confirm('入力内容を破棄しますか?')) {
+              router.push('/board/offers/');
+            }
+          }}
+          disabled={isLoading}
+        >
+          キャンセル
+        </button>
+        {error && (
+          <p role="alert">
+            投稿中にエラーが発生しました。詳細: {error.message}
+          </p>
+        )}
+      </form>
+      <style jsx>
+        {`
+          div:not(first-child) {
+            margin: 16px;
+          }
+          label {
+            vertical-align: top;
+            margin-right: 8px;
+          }
+        `}
+      </style>
     </div>
   );
 }

--- a/pages/offer/post.tsx
+++ b/pages/offer/post.tsx
@@ -51,7 +51,7 @@ const schema = yup.object({
 });
 
 function PostOfferPage() {
-  const { data: tags } = useTags({ tag_genre_id: '1' });
+  const { data: tags } = useTags({ tag_genre_id: 1 });
 
   const {
     mutate: addOffer,

--- a/pages/offer/post.tsx
+++ b/pages/offer/post.tsx
@@ -1,179 +1,35 @@
-import { yupResolver } from '@hookform/resolvers/yup/dist/yup';
 import { useRouter } from 'next/router';
-import { Fragment, useState } from 'react';
 import type { ReactElement } from 'react';
-import { useForm } from 'react-hook-form';
-import type { NestedValue, Resolver } from 'react-hook-form';
-import Modal from 'react-modal';
-import * as yup from 'yup';
 import Layout from '../../components/layouts/Layout';
+import OfferForm from '../../components/OfferForm';
 import { useAddOffer } from '../../hooks/requests/offers';
-import { useTags } from '../../hooks/requests/tags';
-
-type FormValue = {
-  title: string;
-  target: string;
-  job: string;
-  note: string;
-  picture: string;
-  link: string;
-  end_date: string;
-  user_class: string;
-  offer_tag_ids: NestedValue<number[]>;
-};
-
-const schema = yup.object({
-  title: yup.string().required('タイトルは入力が必須です'),
-  target: yup.string(),
-  job: yup.string(),
-  note: yup.string(),
-  picture: yup.string(), //TODO: stringじゃない気がする
-  link: yup.string().url('リンクは有効なURLでなければいけません'),
-  // 投稿内容の入力中に日付を跨いだ場合を考慮してバリデーションのたびに現在日付を取得する
-  end_date: yup.lazy(() => {
-    const today = new Date(new Date().setHours(0, 0, 0, 0)).getTime();
-    const dayInMs = 1000 * 60 * 60 * 24;
-    const min = new Date(today + dayInMs * 1);
-    const max = new Date(today + dayInMs * 90);
-
-    return yup
-      .date()
-      .required('掲載終了日は選択が必須です')
-      .min(min, '掲載終了日は明日以降でなければいけません')
-      .max(max, '掲載終了日は今から90日以内でなければいけません')
-      .nullable()
-      .transform((current, original) => (original === '' ? null : current));
-  }),
-  user_class: yup.string().required('募集主のクラスは入力が必須です'),
-  offer_tag_ids: yup
-    .array(yup.number())
-    .min(1, 'タグは1つ以上選ぶ必要があります')
-    .transform((value) => value.filter(Boolean)),
-});
 
 function PostOfferPage() {
-  const { data: tags } = useTags({ tag_genre_id: 1 });
-
-  const {
-    mutate: addOffer,
-    error: addOfferError,
-    isLoading: isAddingOffer,
-  } = useAddOffer();
-
-  const { register, handleSubmit, formState, watch } = useForm<FormValue>({
-    resolver: yupResolver(schema) as Resolver<FormValue>,
-    defaultValues: { offer_tag_ids: [] },
-  });
-  const onSubmit = handleSubmit((newOfferAttributes) => {
-    addOffer(newOfferAttributes);
-  });
-  const formErrors = formState.errors;
+  const { mutate, error, isLoading } = useAddOffer();
 
   const router = useRouter();
-
-  const [showTagSelector, setShowTagSelector] = useState(false);
-
-  const selectedTags = watch('offer_tag_ids')
-    .filter(Boolean)
-    .map((id) => +id);
 
   return (
     <div>
       <h1>募集投稿</h1>
-      <form onSubmit={onSubmit}>
-        <p>募集主: 2180372 ECC太郎</p>
-        <div>
-          <label htmlFor="title">募集のタイトル</label>
-          <input id="title" type="input" {...register('title')} />
-          {formErrors.title && <span>{formErrors.title.message}</span>}
-        </div>
-        <div className="tags">
-          タグ
-          <Modal
-            isOpen={showTagSelector}
-            onRequestClose={() => setShowTagSelector(false)}
-          >
-            <button onClick={() => setShowTagSelector(false)}>x</button>
-            {tags &&
-              tags.tags.map((tag, i) => (
-                <Fragment key={tag.id}>
-                  <label htmlFor={`tag${i}`}>{tag.name}</label>
-                  <input
-                    id={`tag${i}`}
-                    type="checkbox"
-                    value={tag.id}
-                    {...register(`offer_tag_ids.${i}`)}
-                  />
-                  <br />
-                </Fragment>
-              ))}
-          </Modal>
-          <button onClick={() => setShowTagSelector(true)}>タグ一覧</button>
-          {tags && (
-            <div>
-              {tags.tags
-                .filter(({ id }) => selectedTags.includes(id))
-                .map((tag) => (
-                  <span key={tag.id} className="tag">
-                    #{tag.name}
-                  </span>
-                ))}
-            </div>
-          )}
-          {formErrors.offer_tag_ids && (
-            <span>{formErrors.offer_tag_ids.message}</span>
-          )}
-        </div>
-        <div>
-          <label htmlFor="end-date">掲載終了日</label>
-          <input id="end-date" type="date" {...register('end_date')} />
-          {formErrors.end_date && <span>{formErrors.end_date.message}</span>}
-        </div>
-        <div>
-          <label htmlFor="target">役職ごとの募集人数</label>
-          <textarea id="target" {...register('target')} />
-          {formErrors.target && <span>{formErrors.target.message}</span>}
-        </div>
-        <div>
-          <label htmlFor="note">備考</label>
-          <textarea id="note" {...register('note')} />
-          {formErrors.note && <span>{formErrors.note.message}</span>}
-        </div>
-        <div>
-          <label htmlFor="picture">参考画像</label>
-          <input id="picture" type="file" {...register('picture')} />
-          {formErrors.picture && <span>{formErrors.picture.message}</span>}
-        </div>
-        <div>
-          <label htmlFor="user_class">募集主のクラス</label>
-          <input id="user-class" type="text" {...register('user_class')} />
-          {formErrors.user_class && (
-            <span>{formErrors.user_class.message}</span>
-          )}
-        </div>
-        <div>
-          <label htmlFor="link">参考リンク</label>
-          <input id="link" type="text" {...register('link')} />
-          {formErrors.link && <span>{formErrors.link.message}</span>}
-        </div>
-        <button disabled={isAddingOffer}>投稿</button>
-        <button
-          type="button"
-          onClick={() => {
-            if (confirm('入力内容を破棄しますか?')) {
-              router.push('/board/offers/');
-            }
-          }}
-          disabled={isAddingOffer}
-        >
-          キャンセル
-        </button>
-        {addOfferError && (
-          <p role="alert">
-            投稿中にエラーが発生しました。詳細: {addOfferError.message}
-          </p>
+      <OfferForm
+        onSubmit={(newOfferAttributes) => {
+          mutate(newOfferAttributes, {
+            onSuccess: () => {
+              router.push('/board/offers');
+            },
+          });
+        }}
+        submitButton={() => <button disabled={isLoading}>投稿</button>}
+        cancelButton={({ handleCancel }) => (
+          <button type="button" onClick={handleCancel} disabled={isLoading}>
+            キャンセル
+          </button>
         )}
-      </form>
+      />
+      {error && (
+        <p role="alert">投稿中にエラーが発生しました。詳細: {error.message}</p>
+      )}
       <style jsx>
         {`
           div:not(first-child) {

--- a/pages/offer/post.tsx
+++ b/pages/offer/post.tsx
@@ -28,11 +28,21 @@ const schema = yup.object({
   note: yup.string(),
   picture: yup.string(), //TODO: stringじゃない気がする
   link: yup.string().url('リンクは有効なURLでなければいけません'),
-  end_date: yup
-    .date()
-    .required('掲載終了日は選択が必須です')
-    .nullable()
-    .transform((current, original) => (original === '' ? null : current)),
+  // 投稿内容の入力中に日付を跨いだ場合を考慮してバリデーションのたびに現在日付を取得する
+  end_date: yup.lazy(() => {
+    const today = new Date(new Date().setHours(0, 0, 0, 0)).getTime();
+    const dayInMs = 1000 * 60 * 60 * 24;
+    const min = new Date(today + dayInMs * 1);
+    const max = new Date(today + dayInMs * 90);
+
+    return yup
+      .date()
+      .required('掲載終了日は選択が必須です')
+      .min(min, '掲載終了日は明日以降でなければいけません')
+      .max(max, '掲載終了日は今から90日以内でなければいけません')
+      .nullable()
+      .transform((current, original) => (original === '' ? null : current));
+  }),
   user_class: yup.string().required('募集主のクラスは入力が必須です'),
   offer_tag_ids: yup
     .array(yup.number())


### PR DESCRIPTION
## 概要
募集投稿画面と募集編集画面を作ってそれぞれAPIを叩ける様にしました。

## メモ
冬休み中なのでレビューに時間がかかったりして作業が滞ると困るということもあって、割とデカめのプルリクに育ちました。

## やったこと
- 募集投稿画面と募集編集画面はほとんど同じなので、共通するコンポーネントを作りました。投稿と編集でフォーム送信時やキャンセルした時の動きが違うだけでなく、送信やキャンセルのボタン自体が変わる可能性もあると思ったのでRenderPropsを採用しました
- フォームにバリデーションを追加しました。参考画像はバックエンドの仕様が固まってないと思うので適当に文字列扱いにしてます。
- 募集一覧画面から募集投稿画面に飛べなかったのでリンクを追加しておきました。