### PR TITLE
Add ユーザープロフィール関連の画面

### DIFF
--- a/components/OfferOverview.tsx
+++ b/components/OfferOverview.tsx
@@ -1,34 +1,46 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 import type { Offer } from '../hooks/requests/offers';
 
 type Props = {
   offer: Offer;
+  editable?: boolean;
 };
 
-export default function OfferOverview({ offer }: Props) {
+export default function OfferOverview({ offer, editable = false }: Props) {
   const [showMenu, setShowMenu] = useState(false);
   const daysBeforeExpiration = getDaysBeforeExpiration(
     new Date(offer.end_date)
   );
 
+  const router = useRouter();
+
   return (
     <div className="offer-overview">
-      <button
-        aria-label="メニューを開く"
-        onClick={() => setShowMenu((b) => !b)}
-      >
-        。。。
-      </button>
-      {showMenu ? (
-        <>
-          <div className="overlay" onClick={() => setShowMenu(false)} />
-          <div className="menu-popup">
-            <button onClick={() => alert(`応募${offer.id}を編集`)}>編集</button>
-            <button onClick={() => alert(`応募${offer.id}を削除`)}>削除</button>
-          </div>
-        </>
-      ) : null}
+      {editable && (
+        <div>
+          <button
+            aria-label="メニューを開く"
+            onClick={() => setShowMenu((b) => !b)}
+          >
+            。。。
+          </button>
+          {showMenu ? (
+            <>
+              <div className="overlay" onClick={() => setShowMenu(false)} />
+              <div className="menu-popup">
+                <button onClick={() => router.push(`/offer/edit/${offer.id}`)}>
+                  編集
+                </button>
+                <button onClick={() => alert(`応募${offer.id}を削除`)}>
+                  削除
+                </button>
+              </div>
+            </>
+          ) : null}
+        </div>
+      )}
       <h2>
         <Link href={`/board/offers/${offer.id}`}>{offer.title}</Link>
       </h2>

--- a/components/UserOfferProvider.tsx
+++ b/components/UserOfferProvider.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import { useUserOffers } from '../hooks/requests/offers';
+
+type Props = {
+  studentNumber: string;
+  children: (queryResult: ReturnType<typeof useUserOffers>) => ReactNode;
+};
+
+export default function UserOfferProvider({ studentNumber, children }: Props) {
+  const data = useUserOffers(
+    { student_number: studentNumber },
+    studentNumber !== undefined
+  );
+
+  return <>{children(data)}</>;
+}

--- a/hooks/forms/useEmailForm.ts
+++ b/hooks/forms/useEmailForm.ts
@@ -1,0 +1,24 @@
+import { yupResolver } from '@hookform/resolvers/yup/dist/yup';
+import { useForm } from 'react-hook-form';
+import type { DefaultValues } from 'react-hook-form';
+import * as yup from 'yup';
+
+type FormValue = {
+  email: string;
+};
+
+const schema = yup.object({
+  email: yup
+    .string()
+    .required('メールアドレスは必須です')
+    .email('有効なメールアドレスを入力してください'),
+});
+
+function useEmailForm(defaultValues?: DefaultValues<FormValue>) {
+  return useForm<FormValue>({
+    resolver: yupResolver(schema),
+    defaultValues: defaultValues,
+  });
+}
+
+export { useEmailForm };

--- a/hooks/forms/useProfileForm.ts
+++ b/hooks/forms/useProfileForm.ts
@@ -1,0 +1,25 @@
+import { yupResolver } from '@hookform/resolvers/yup/dist/yup';
+import { useForm } from 'react-hook-form';
+import type { DefaultValues } from 'react-hook-form';
+import * as yup from 'yup';
+
+type FormValue = {
+  user_name: string;
+  link: string;
+  self_introduction: string;
+};
+
+const schema = yup.object({
+  user_name: yup.string().required('ユーザーネームは必須です'),
+  link: yup.string().url('有効なURLを入力してください'),
+  self_introduction: yup.string(),
+});
+
+function useProfileForm(defaultValues?: DefaultValues<FormValue>) {
+  return useForm<FormValue>({
+    resolver: yupResolver(schema),
+    defaultValues: defaultValues,
+  });
+}
+
+export { useProfileForm };

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -57,6 +57,11 @@ type EditOfferResponse = {
   offer: Offer;
 };
 
+type GetUserOffersRequest = { student_number: string };
+type GetUserOffersResponse = {
+  offers: Offer[];
+};
+
 function useInfiniteOffers(options: GetOffersRequest = {}) {
   const queryClient = useQueryClient();
   return useInfiniteQuery<GetOffersResponse, Error>(
@@ -137,5 +142,35 @@ function useEditOffer() {
   );
 }
 
+function useUserOffers(
+  { student_number }: GetUserOffersRequest,
+  enabled = true
+) {
+  const queryClient = useQueryClient();
+  return useQuery<GetUserOffersResponse>(
+    ['offers', 'user', student_number],
+    () =>
+      jsonClient('/user/offer-list', {
+        params: {
+          student_number,
+        },
+      }),
+    {
+      enabled,
+      onSuccess: (data) => {
+        data.offers.forEach((offer) => {
+          queryClient.setQueryData(['offer', offer.id], { offer });
+        });
+      },
+    }
+  );
+}
+
 export type { Offer };
-export { useAddOffer, useEditOffer, useInfiniteOffers, useOffer };
+export {
+  useAddOffer,
+  useEditOffer,
+  useInfiniteOffers,
+  useOffer,
+  useUserOffers,
+};

--- a/hooks/requests/profile.ts
+++ b/hooks/requests/profile.ts
@@ -1,0 +1,37 @@
+import { useMutation } from 'react-query';
+import { jsonClient } from '../../utils/httpClient';
+
+type User = {
+  student_number: number;
+  user_name: string;
+  email?: string;
+  link?: string;
+  self_introduction: string;
+};
+
+type EditUserRequest = {
+  user_name: string;
+  link?: string;
+  self_introduction?: string;
+};
+type EditUserResponse = {
+  user: User;
+};
+
+function useEditUser() {
+  return useMutation<EditUserResponse, Error, EditUserRequest>(
+    (newUser) => {
+      return jsonClient('/mock/user/edit', {
+        method: 'POST',
+        body: { ...newUser },
+      });
+    },
+    {
+      onSuccess: (data) => {
+        // TODO ログインユーザーをアップデートする
+      },
+    }
+  );
+}
+export type { User };
+export { useEditUser };

--- a/hooks/requests/profile.ts
+++ b/hooks/requests/profile.ts
@@ -18,6 +18,13 @@ type EditUserResponse = {
   user: User;
 };
 
+type EditEmailRequest = {
+  email: string;
+};
+type EditEmailResponse = {
+  user: User;
+};
+
 function useEditUser() {
   return useMutation<EditUserResponse, Error, EditUserRequest>(
     (newUser) => {
@@ -33,5 +40,21 @@ function useEditUser() {
     }
   );
 }
+
+function useEditEmail() {
+  return useMutation<EditEmailResponse, Error, EditEmailRequest>(
+    (newEmail) => {
+      return jsonClient('/mock/user/edit-email', {
+        method: 'POST',
+        body: { ...newEmail },
+      });
+    },
+    {
+      onSuccess: () => {
+        // TODO ログインユーザーのemailをアップデートする
+      },
+    }
+  );
+}
 export type { User };
-export { useEditUser };
+export { useEditUser, useEditEmail };

--- a/mocks/handlers/profile.ts
+++ b/mocks/handlers/profile.ts
@@ -10,7 +10,7 @@ export const profileHandlers = [
       })
     );
   }),
-  rest.get('/user/edit', (req, res, ctx) => {
+  rest.post('/mock/user/edit', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/mocks/handlers/profile.ts
+++ b/mocks/handlers/profile.ts
@@ -26,7 +26,7 @@ export const profileHandlers = [
       })
     );
   }),
-  rest.get('/user/edit-email', (req, res, ctx) => {
+  rest.post('/mock/user/edit-email', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-hook-form": "^7.20.5",
         "react-modal": "^3.14.4",
         "react-query": "3.33.7",
+        "react-tabs": "^3.2.3",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/node": "^16.11.8",
         "@types/react": "^17.0.35",
+        "@types/react-tabs": "^2.3.4",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "babel-jest": "^27.3.1",
         "eslint": "^7.32.0",
@@ -2028,6 +2030,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-tabs": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.4.tgz",
+      "integrity": "sha512-HQzhKW+RF/7h14APw/2cu4Nnt+GmsTvfBKbFdn/NbYpb8Q+iB65wIkPHz4VRKDxWtOpNFpOUtzt5r0LRmQMfOA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-test-renderer": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
@@ -3200,6 +3211,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -8673,6 +8692,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-tabs": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.3.tgz",
+      "integrity": "sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0-0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -11816,6 +11847,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-tabs": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.4.tgz",
+      "integrity": "sha512-HQzhKW+RF/7h14APw/2cu4Nnt+GmsTvfBKbFdn/NbYpb8Q+iB65wIkPHz4VRKDxWtOpNFpOUtzt5r0LRmQMfOA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-test-renderer": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
@@ -12699,6 +12739,11 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "4.6.0",
@@ -16830,6 +16875,15 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+    },
+    "react-tabs": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.2.3.tgz",
+      "integrity": "sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
+      }
     },
     "readable-stream": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-hook-form": "^7.20.5",
     "react-modal": "^3.14.4",
     "react-query": "3.33.7",
+    "react-tabs": "^3.2.3",
     "yup": "^0.32.11"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/node": "^16.11.8",
     "@types/react": "^17.0.35",
+    "@types/react-tabs": "^2.3.4",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "babel-jest": "^27.3.1",
     "eslint": "^7.32.0",

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -17,6 +17,7 @@ function AllOffersPage() {
 
   return (
     <div>
+      <Link href="/user/2180372">マイページ</Link>
       <h1>募集一覧</h1>
       <div>
         <Link href="/offer/post">投稿する</Link>

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import { resetIdCounter, Tab, Tabs, TabList, TabPanel } from 'react-tabs';
@@ -58,6 +59,9 @@ function UserProfilePage() {
   const router = useRouter();
   const userId = router.query.userId as string;
 
+  // TODO: userログインユーザーと取得したユーザー情報を比較する
+  const isLoginUser = userId === user.student_number.toString();
+
   return (
     <div>
       <h1>ユーザー詳細</h1>
@@ -68,6 +72,16 @@ function UserProfilePage() {
         <p>
           Webサイト: <a href={user.link}>{user.link}</a>
         </p>
+        {isLoginUser && (
+          <div>
+            <Link href="/user/edit/profile">
+              <a className="edit-link">プロフィールを編集</a>
+            </Link>
+            <Link href="/user/edit/email">
+              <a className="edit-link">登録メールアドレスを編集</a>
+            </Link>
+          </div>
+        )}
       </div>
       <h2>{user.user_name}さんの投稿</h2>
       <Tabs selectedTabClassName="selected-tab">
@@ -81,7 +95,11 @@ function UserProfilePage() {
             {({ data }) =>
               data
                 ? data.offers.map((offer) => (
-                    <OfferOverview key={offer.id} offer={offer}></OfferOverview>
+                    <OfferOverview
+                      key={offer.id}
+                      offer={offer}
+                      editable={isLoginUser}
+                    ></OfferOverview>
                   ))
                 : 'ロード中'
             }
@@ -108,6 +126,21 @@ function UserProfilePage() {
             line-height: 1.8;
             text-decoration: underline;
             margin: 8px 12px;
+          }
+          .edit-link {
+            display: inline-block;
+            margin: 4px 8px;
+            padding: 4px 8px;
+            border: 1px solid tomato;
+            border-radius: 4px;
+            text-decoration: none;
+            color: white;
+            background-color: tomato;
+          }
+          .edit-link:hover {
+            background-color: red;
+            color: white;
+            border-color: red;
           }
         `}
       </style>

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -64,6 +64,7 @@ function UserProfilePage() {
 
   return (
     <div>
+      <Link href="/board/offers">ガウディーボード</Link>
       <h1>ユーザー詳細</h1>
       <div className="user-info">
         <p>学籍番号: {user.student_number}</p>

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -2,22 +2,16 @@ import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../components/layouts/Layout';
 import OfferOverview from '../../components/OfferOverview';
-import { useUserOffers } from '../../hooks/requests/offers';
+import UserOfferProvider from '../../components/UserOfferProvider';
 import { user } from '../../mocks/handlers/auth';
 
 function UserProfilePage() {
   const router = useRouter();
   const userId = router.query.userId as string;
 
-  const { data, isLoading } = useUserOffers(
-    { student_number: userId },
-    router.isReady
-  );
-
   return (
     <div>
       <h1>ユーザー詳細</h1>
-      {isLoading && <p>データをロード中</p>}
       <div className="user-info">
         <p>学籍番号: {user.student_number}</p>
         <p>名前: {user.user_name}</p>
@@ -33,13 +27,17 @@ function UserProfilePage() {
         <li role="button">投稿した宣伝</li>
         <li role="button">投稿した作品</li>
       </ul>
-      {data && (
-        <div>
-          {data.offers.map((offer) => (
-            <OfferOverview key={offer.id} offer={offer}></OfferOverview>
-          ))}
-        </div>
-      )}
+      <div className="post-list">
+        <UserOfferProvider studentNumber={userId}>
+          {({ data }) =>
+            data
+              ? data.offers.map((offer) => (
+                  <OfferOverview key={offer.id} offer={offer}></OfferOverview>
+                ))
+              : 'ロード中'
+          }
+        </UserOfferProvider>
+      </div>
       <style jsx>
         {`
           .tab {

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -1,11 +1,60 @@
 import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
+import { resetIdCounter, Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import css from 'styled-jsx/css';
 import Layout from '../../components/layouts/Layout';
 import OfferOverview from '../../components/OfferOverview';
 import UserOfferProvider from '../../components/UserOfferProvider';
 import { user } from '../../mocks/handlers/auth';
 
 function UserProfilePage() {
+  // https://github.com/reactjs/react-tabs#resetidcounter-void
+  if (typeof window === 'undefined') {
+    resetIdCounter();
+  }
+
+  const { className: scopedTabListClass, styles: tabListStyles } = css.resolve`
+    .tab-list {
+      border-bottom: 1px solid gray;
+      width: fit-content;
+      margin: 8px;
+      padding-right: 28px;
+    }
+  `;
+
+  const { className: scopedTabClass, styles: tabStyles } = css.resolve`
+    .tab {
+      display: inline-block;
+      margin-right: 8px;
+      padding: 4px;
+      border: solid gray;
+      border-width: 1px 1px 0 1px;
+      border-radius: 4px 4px 0 0;
+      cursor: pointer;
+    }
+    .tab:hover {
+      background-color: lightgray;
+    }
+    .tab.selected-tab {
+      background-color: gray;
+    }
+  `;
+
+  const {
+    className: scopedTabPanelClass,
+    styles: tabPanelStyles,
+  } = css.resolve`
+    .tab-panel {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: start;
+      margin: 0 10px;
+    }
+  `;
+
+  const tabClass = `tab ${scopedTabClass}`;
+  const tabPanelClass = `tab-panel ${scopedTabPanelClass}`;
+
   const router = useRouter();
   const userId = router.query.userId as string;
 
@@ -20,47 +69,33 @@ function UserProfilePage() {
           Webサイト: <a href={user.link}>{user.link}</a>
         </p>
       </div>
-      <ul className="tab">
-        <li role="button" className="selected">
-          投稿した募集
-        </li>
-        <li role="button">投稿した宣伝</li>
-        <li role="button">投稿した作品</li>
-      </ul>
-      <div className="post-list">
-        <UserOfferProvider studentNumber={userId}>
-          {({ data }) =>
-            data
-              ? data.offers.map((offer) => (
-                  <OfferOverview key={offer.id} offer={offer}></OfferOverview>
-                ))
-              : 'ロード中'
-          }
-        </UserOfferProvider>
-      </div>
+      <h2>{user.user_name}さんの投稿</h2>
+      <Tabs selectedTabClassName="selected-tab">
+        <TabList className={`tab-list ${scopedTabListClass}`}>
+          <Tab className={tabClass}>募集</Tab>
+          <Tab className={tabClass}>宣伝</Tab>
+          <Tab className={tabClass}>作品</Tab>
+        </TabList>
+        <TabPanel className={tabPanelClass}>
+          <UserOfferProvider studentNumber={userId}>
+            {({ data }) =>
+              data
+                ? data.offers.map((offer) => (
+                    <OfferOverview key={offer.id} offer={offer}></OfferOverview>
+                  ))
+                : 'ロード中'
+            }
+          </UserOfferProvider>
+        </TabPanel>
+        <TabPanel className={tabPanelClass}>
+          <h3>宣伝</h3>
+        </TabPanel>
+        <TabPanel className={tabPanelClass}>
+          <h3>作品</h3>
+        </TabPanel>
+      </Tabs>
       <style jsx>
         {`
-          .tab {
-            border-bottom: 1px solid gray;
-            width: fit-content;
-            margin: 8px;
-            padding-right: 28px;
-          }
-          .tab > li {
-            display: inline-block;
-            margin-right: 8px;
-            padding: 4px;
-            border: solid gray;
-            border-width: 1px 1px 0 1px;
-            border-radius: 4px 4px 0 0;
-            cursor: pointer;
-          }
-          .tab > li:hover {
-            background-color: lightgray;
-          }
-          .tab > li.selected {
-            background-color: lightgray;
-          }
           .user-info {
             background-color: white;
             margin: 24px auto 24px auto;
@@ -76,6 +111,9 @@ function UserProfilePage() {
           }
         `}
       </style>
+      {tabListStyles}
+      {tabStyles}
+      {tabPanelStyles}
     </div>
   );
 }

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -1,10 +1,83 @@
+import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../components/layouts/Layout';
+import OfferOverview from '../../components/OfferOverview';
+import { useUserOffers } from '../../hooks/requests/offers';
+import { user } from '../../mocks/handlers/auth';
 
 function UserProfilePage() {
+  const router = useRouter();
+  const userId = router.query.userId as string;
+
+  const { data, isLoading } = useUserOffers(
+    { student_number: userId },
+    router.isReady
+  );
+
   return (
     <div>
       <h1>ユーザー詳細</h1>
+      {isLoading && <p>データをロード中</p>}
+      <div className="user-info">
+        <p>学籍番号: {user.student_number}</p>
+        <p>名前: {user.user_name}</p>
+        <p className="self-introduction">{user.self_introduction}</p>
+        <p>
+          Webサイト: <a href={user.link}>{user.link}</a>
+        </p>
+      </div>
+      <ul className="tab">
+        <li role="button" className="selected">
+          投稿した募集
+        </li>
+        <li role="button">投稿した宣伝</li>
+        <li role="button">投稿した作品</li>
+      </ul>
+      {data && (
+        <div>
+          {data.offers.map((offer) => (
+            <OfferOverview key={offer.id} offer={offer}></OfferOverview>
+          ))}
+        </div>
+      )}
+      <style jsx>
+        {`
+          .tab {
+            border-bottom: 1px solid gray;
+            width: fit-content;
+            margin: 8px;
+            padding-right: 28px;
+          }
+          .tab > li {
+            display: inline-block;
+            margin-right: 8px;
+            padding: 4px;
+            border: solid gray;
+            border-width: 1px 1px 0 1px;
+            border-radius: 4px 4px 0 0;
+            cursor: pointer;
+          }
+          .tab > li:hover {
+            background-color: lightgray;
+          }
+          .tab > li.selected {
+            background-color: lightgray;
+          }
+          .user-info {
+            background-color: white;
+            margin: 24px auto 24px auto;
+            width: 60%;
+            padding: 12px;
+            border: 1px solid gray;
+            border-radius: 12px;
+          }
+          .user-info > .self-introduction {
+            line-height: 1.8;
+            text-decoration: underline;
+            margin: 8px 12px;
+          }
+        `}
+      </style>
     </div>
   );
 }

--- a/pages/user/edit/email.tsx
+++ b/pages/user/edit/email.tsx
@@ -1,10 +1,56 @@
+import Router from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../../components/layouts/Layout';
+import { useEmailForm } from '../../../hooks/forms/useEmailForm';
+import { user } from '../../../mocks/handlers/auth';
 
 function EditEmailPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useEmailForm();
+
+  const onSubmit = handleSubmit((data) => {
+    console.log('submitting with ', data);
+  });
+  const handleCancel = () => {
+    if (confirm('入力内容を破棄しますか?')) {
+      Router.push(`/user/${user.student_number}`);
+    }
+  };
+
   return (
     <div>
       <h1>メールアドレス変更</h1>
+      {user && (
+        <>
+          <form onSubmit={onSubmit}>
+            <p>現在のメールアドレス: {user.email}</p>
+            <div>
+              <label htmlFor="email">新しいメールアドレス</label>
+              <input id="email" type="text" {...register('email')} />
+              {errors.email && <span role="alert">{errors.email.message}</span>}
+            </div>
+            <button>変更</button>
+            <button type="button" onClick={handleCancel}>
+              キャンセル
+            </button>
+          </form>
+        </>
+      )}
+      <style jsx>{`
+        form {
+          margin: 8px;
+        }
+        div,
+        p {
+          margin-bottom: 16px;
+        }
+        label {
+          margin-right: 8px;
+        }
+      `}</style>
     </div>
   );
 }

--- a/pages/user/edit/email.tsx
+++ b/pages/user/edit/email.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from 'react';
 import Modal from 'react-modal';
 import Layout from '../../../components/layouts/Layout';
 import { useEmailForm } from '../../../hooks/forms/useEmailForm';
+import { useEditEmail } from '../../../hooks/requests/profile';
 import { user } from '../../../mocks/handlers/auth';
 
 function EditEmailPage() {
@@ -15,10 +16,16 @@ function EditEmailPage() {
     getValues,
   } = useEmailForm();
 
+  const { mutate, error, isLoading } = useEditEmail();
+
   const router = useRouter();
 
-  const onSubmit = handleSubmit(() => {
-    setShowModal(true);
+  const onSubmit = handleSubmit((data) => {
+    mutate(data, {
+      onSuccess: () => {
+        setShowModal(true);
+      },
+    });
   });
   const handleCancel = () => {
     if (confirm('入力内容を破棄しますか?')) {
@@ -41,11 +48,16 @@ function EditEmailPage() {
               <input id="email" type="text" {...register('email')} />
               {errors.email && <span role="alert">{errors.email.message}</span>}
             </div>
-            <button>変更</button>
-            <button type="button" onClick={handleCancel}>
+            <button disabled={isLoading}>変更</button>
+            <button type="button" onClick={handleCancel} disabled={isLoading}>
               キャンセル
             </button>
           </form>
+          {error && (
+            <p role="alert">
+              編集中にエラーが発生しました。詳細: {error.message}
+            </p>
+          )}
         </>
       )}
       <Modal isOpen={showModal}>

--- a/pages/user/edit/email.tsx
+++ b/pages/user/edit/email.tsx
@@ -1,23 +1,32 @@
-import Router from 'next/router';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
+import Modal from 'react-modal';
 import Layout from '../../../components/layouts/Layout';
 import { useEmailForm } from '../../../hooks/forms/useEmailForm';
 import { user } from '../../../mocks/handlers/auth';
 
 function EditEmailPage() {
+  const [showModal, setShowModal] = useState(false);
   const {
     register,
     handleSubmit,
     formState: { errors },
+    getValues,
   } = useEmailForm();
 
-  const onSubmit = handleSubmit((data) => {
-    console.log('submitting with ', data);
+  const router = useRouter();
+
+  const onSubmit = handleSubmit(() => {
+    setShowModal(true);
   });
   const handleCancel = () => {
     if (confirm('入力内容を破棄しますか?')) {
-      Router.push(`/user/${user.student_number}`);
+      router.push(`/user/${user.student_number}`);
     }
+  };
+  const handleDone = () => {
+    router.push(`/user/${user.student_number}`);
   };
 
   return (
@@ -39,6 +48,14 @@ function EditEmailPage() {
           </form>
         </>
       )}
+      <Modal isOpen={showModal}>
+        <h3>新しいメールアドレスの認証が必要です</h3>
+        <p className="modal-message">
+          <span className="new-email">{getValues('email')}</span>
+          に認証メールを送りました。送られたメールに従ってメールアドレスを認証してください。
+        </p>
+        <button onClick={handleDone}>閉じる</button>
+      </Modal>
       <style jsx>{`
         form {
           margin: 8px;
@@ -49,6 +66,14 @@ function EditEmailPage() {
         }
         label {
           margin-right: 8px;
+        }
+        .modal-message {
+          margin: 8px;
+        }
+        .new-email {
+          font-size: 1.2rem;
+          padding-inline: 4px;
+          color: tomato;
         }
       `}</style>
     </div>

--- a/pages/user/edit/profile.tsx
+++ b/pages/user/edit/profile.tsx
@@ -1,10 +1,59 @@
+import Router from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../../components/layouts/Layout';
+import { useProfileForm } from '../../../hooks/forms/useProfileForm';
+import { user } from '../../../mocks/handlers/auth';
 
 function EditProfilePage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useProfileForm(user);
+
+  const onSubmit = handleSubmit((data) => {
+    console.log('submitting with', data);
+  });
+
+  const handleCancel = () => {
+    if (confirm('入力内容を破棄しますか?')) {
+      Router.push(`/user/${user.student_number}`);
+    }
+  };
+
   return (
     <div>
       <h1>ユーザー情報変更</h1>
+      {user && (
+        <div>
+          <form onSubmit={onSubmit}>
+            <div>
+              <label htmlFor="user-name">ユーザーネーム</label>
+              <input id="user-name" type="text" {...register('user_name')} />
+              {errors.user_name && <span>{errors.user_name.message}</span>}
+            </div>
+            <div>
+              <label htmlFor="link">自分のWebサイト</label>
+              <input id="link" type="text" {...register('link')} />
+              {errors.link && <span>{errors.link.message}</span>}
+            </div>
+            <div>
+              <label htmlFor="self-introduction">自己紹介</label>
+              <textarea
+                id="self-introduction"
+                {...register('self_introduction')}
+              />
+              {errors.self_introduction && (
+                <span>{errors.self_introduction.message}</span>
+              )}
+            </div>
+            <button>変更</button>
+            <button type="button" onClick={handleCancel}>
+              キャンセル
+            </button>
+          </form>
+        </div>
+      )}
     </div>
   );
 }

--- a/pages/user/edit/profile.tsx
+++ b/pages/user/edit/profile.tsx
@@ -68,6 +68,17 @@ function EditProfilePage() {
           )}
         </>
       )}
+      <style jsx>{`
+        form {
+          margin: 8px;
+        }
+        div {
+          margin-bottom: 16px;
+        }
+        label {
+          margin-right: 8px;
+        }
+      `}</style>
     </div>
   );
 }

--- a/pages/user/edit/profile.tsx
+++ b/pages/user/edit/profile.tsx
@@ -1,7 +1,8 @@
-import Router from 'next/router';
+import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../../components/layouts/Layout';
 import { useProfileForm } from '../../../hooks/forms/useProfileForm';
+import { useEditUser } from '../../../hooks/requests/profile';
 import { user } from '../../../mocks/handlers/auth';
 
 function EditProfilePage() {
@@ -11,13 +12,21 @@ function EditProfilePage() {
     formState: { errors },
   } = useProfileForm(user);
 
+  const { mutate, error, isLoading } = useEditUser();
+
+  const router = useRouter();
+
   const onSubmit = handleSubmit((data) => {
-    console.log('submitting with', data);
+    mutate(data, {
+      onSuccess: () => {
+        router.push(`/user/${user.student_number}`);
+      },
+    });
   });
 
   const handleCancel = () => {
     if (confirm('入力内容を破棄しますか?')) {
-      Router.push(`/user/${user.student_number}`);
+      router.push(`/user/${user.student_number}`);
     }
   };
 
@@ -25,7 +34,7 @@ function EditProfilePage() {
     <div>
       <h1>ユーザー情報変更</h1>
       {user && (
-        <div>
+        <>
           <form onSubmit={onSubmit}>
             <div>
               <label htmlFor="user-name">ユーザーネーム</label>
@@ -47,12 +56,17 @@ function EditProfilePage() {
                 <span>{errors.self_introduction.message}</span>
               )}
             </div>
-            <button>変更</button>
-            <button type="button" onClick={handleCancel}>
+            <button disabled={isLoading}>変更</button>
+            <button type="button" onClick={handleCancel} disabled={isLoading}>
               キャンセル
             </button>
           </form>
-        </div>
+          {error && (
+            <p role="alert">
+              編集中にエラーが発生しました。詳細: {error.message}
+            </p>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## 概要
プロフィール関連の雑な画面と機能を作りました。

## やったこと
- プロフィール画面、プロフィール編集画面、メールアドレス編集画面を作りました。
- ログインユーザーの投稿だけ編集できる様にするために、投稿のOverviewコンポーネントに編集可能かを設定できる様にしました。

## メモ
募集編集画面では、投稿画面と共有するFormコンポーネントを作りましたが、今回はuseFormをカスタムフック化するだけにしました。投稿画面と編集画面は今のところ見た目がほぼ一緒なだけで要件的には別物に育っていく可能性があるのでUIは共通化せずにそれぞれで決めれる方がいいのかなって思い始めてます。