### PR TITLE
Add 募集一覧画面の絞り込み機能

### DIFF
--- a/components/PopupMenu.tsx
+++ b/components/PopupMenu.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode, MouseEvent } from 'react';
+
+type Props = {
+  isOpen: boolean;
+  onRequestClose?: (event: MouseEvent) => void;
+  className?: string;
+  children: ReactNode;
+};
+
+export default function PopupMenu({
+  isOpen,
+  onRequestClose,
+  className,
+  children,
+}: Props) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="overlay" onClick={onRequestClose} />
+      <div className={className || ''}>{children}</div>
+      <style jsx>{`
+        .overlay {
+          position: fixed;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/components/TagProvider.tsx
+++ b/components/TagProvider.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+import { useTags } from '../hooks/requests/tags';
+
+type Props = {
+  tag_genre_id: number;
+  children: (queryResult: ReturnType<typeof useTags>) => ReactNode;
+};
+
+export default function TagProvider({ tag_genre_id, children }: Props) {
+  const data = useTags({ tag_genre_id });
+
+  return <>{children(data)}</>;
+}

--- a/hooks/forms/useOfferSearchForm.ts
+++ b/hooks/forms/useOfferSearchForm.ts
@@ -1,0 +1,24 @@
+import { yupResolver } from '@hookform/resolvers/yup/dist/yup';
+import { useForm } from 'react-hook-form';
+import type { DefaultValues, NestedValue, Resolver } from 'react-hook-form';
+import * as yup from 'yup';
+
+type FormValue = {
+  offer_tag_ids: NestedValue<number[]>;
+};
+
+const schema = yup.object({
+  offer_tag_ids: yup
+    .array(yup.number())
+    .required()
+    .transform((value) => value.filter(Boolean)),
+});
+
+function useOfferSearchForm(defaultValues?: DefaultValues<FormValue>) {
+  return useForm<FormValue>({
+    resolver: yupResolver(schema) as Resolver<FormValue>,
+    defaultValues: { offer_tag_ids: [], ...defaultValues },
+  });
+}
+
+export { useOfferSearchForm };

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -62,17 +62,21 @@ type GetUserOffersResponse = {
   offers: Offer[];
 };
 
-function useInfiniteOffers(options: GetOffersRequest = {}) {
+function useInfiniteOffers(
+  { page = '1', offer_tag_ids = [] }: GetOffersRequest = {},
+  enabled = true
+) {
   const queryClient = useQueryClient();
   return useInfiniteQuery<GetOffersResponse, Error>(
-    'offers',
+    ['offers', offer_tag_ids],
     ({ pageParam }) => {
-      pageParam || (pageParam = options.page || 1);
+      pageParam || (pageParam = page);
       return jsonClient('/offer/list', {
-        params: { ...options, page: pageParam },
+        params: { offer_tag_ids, page: pageParam },
       });
     },
     {
+      enabled,
       getNextPageParam: (lastPage) => {
         const nextPage = lastPage.meta.current_page + 1;
         return lastPage.meta.last_page >= nextPage ? nextPage : false;

--- a/hooks/requests/tags.ts
+++ b/hooks/requests/tags.ts
@@ -18,7 +18,7 @@ type GetTagsResponse = {
 };
 
 function useTags({ tag_genre_id }: GetTagsRequest) {
-  return useQuery<GetTagsResponse>(
+  return useQuery<GetTagsResponse, Error>(
     ['tags', { tag_genre_id }],
     () =>
       jsonClient('/tag-list', {

--- a/pages/__tests__/AllOffersPage.test.tsx
+++ b/pages/__tests__/AllOffersPage.test.tsx
@@ -11,6 +11,13 @@ const fakeQueryClient = new QueryClient({
   },
 });
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+  }),
+}));
+
 describe('AllOffersPage', () => {
   it('募集一覧が表示される', async () => {
     render(

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -1,12 +1,29 @@
 import Link from 'next/link';
 import type { ReactElement } from 'react';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
+import css from 'styled-jsx/css';
 import Header from '../../../components/layouts/Header';
 import Layout from '../../../components/layouts/Layout';
 import OfferOverview from '../../../components/OfferOverview';
+import PopupMenu from '../../../components/PopupMenu';
+import TagProvider from '../../../components/TagProvider';
 import { useInfiniteOffers } from '../../../hooks/requests/offers';
 
 function AllOffersPage() {
+  const [showFilter, setShowFilter] = useState(false);
+
+  const { className: filterClassName, styles: filterStyle } = css.resolve`
+    .filter-popup {
+      position: absolute;
+      width: 40%;
+      height: 480px;
+      margin-left: 4px;
+      background-color: white;
+      border-radius: 8px;
+      border: solid grey 1px;
+    }
+  `;
+
   const {
     data,
     error,
@@ -16,12 +33,44 @@ function AllOffersPage() {
     isFetchingNextPage,
   } = useInfiniteOffers();
 
+  const toggleFilter = () => {
+    setShowFilter((b) => !b);
+  };
+
   return (
     <div>
       <h1>募集一覧</h1>
       <div>
         <Link href="/offer/post">投稿する</Link>
       </div>
+      <button onClick={toggleFilter}>フィルター</button>
+      <PopupMenu
+        isOpen={showFilter}
+        onRequestClose={() => setShowFilter(false)}
+        className={`${filterClassName} filter-popup`}
+      >
+        <TagProvider tag_genre_id={1}>
+          {({ data, isLoading, error }) => (
+            <form className="filter-popup">
+              {isLoading && <span>ロード中...</span>}
+              {error && (
+                <span>エラーが発生しました。詳細: {error.message}</span>
+              )}
+              {data &&
+                data.tags.map((tag) => (
+                  <label key={tag.id} className="filter-option">
+                    {tag.name}
+                    <input type="checkbox" value={tag.id} />
+                  </label>
+                ))}
+              <br />
+              <button onClick={() => setShowFilter(false)}>
+                この条件で検索
+              </button>
+            </form>
+          )}
+        </TagProvider>
+      </PopupMenu>
       {error && <p role="alert">エラーが発生しました。詳細: error.message</p>}
       {data && (
         <div className="offers-container">
@@ -53,8 +102,13 @@ function AllOffersPage() {
             align-items: start;
             margin: 10px;
           }
+          .filter-option {
+            white-space: nowrap;
+            margin: 8px;
+          }
         `}
       </style>
+      {filterStyle}
     </div>
   );
 }

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -91,6 +91,7 @@ function AllOffersPage() {
                       id={`tag${i}`}
                       type="checkbox"
                       value={tag.id}
+                      defaultChecked={offer_tag_ids.includes(tag.id)}
                       {...register(`offer_tag_ids.${i}`)}
                     />
                   </Fragment>


### PR DESCRIPTION
## 概要
募集一覧画面でタグによる絞り込み機能を実装しました

## メモ
### PopupMenuコンポーネント
絞り込みのポップアップやその他メニュー選択などで出てくるものはモーダルのような見た目だけど、モダールではない気がしたのでPopupMenuというコンポーネントを別に作りました。PopupMenuとModal(react-modal)の違いですが、Modalはタブトラップされたり、モーダルの背後にあるコンテンツがスクリーンリーダーに見えなくなったりしますが、PopupMenuはそうなりません。

### AllOfferPageのshouldWaitFetchステート
router.queryが初回レンダリング時に空オブジェクトになる都合で、他のページではrouter.isReadyを使ってAPIコールの発火タイミングをコントロールしていました。
queryが必ずつくルート(`/user/[userId]`など)ではそれで動き的には問題ないのですが、募集一覧ページのようにクエリパラメタがつく場合とつかない場合があるルートでは問題がありました。
 クエリパラメタがつかない場合router.isReadyの値が、サーバービルド時ではfalse、ブラウザの初回レンダリングでtrueになってしまい、表示するDOMがisReadyに依存している場合にハイドレーションでreactのwarningが出ます。
なのでuseEffectでAPIをコールしていいかを見張ることにしています。

### その他
テストが全然書けてないのだけど書く時間がない。。