### PR TITLE
Add 応募モーダルで応募ができるようにした

### DIFF
--- a/components/OrderedPages.tsx
+++ b/components/OrderedPages.tsx
@@ -110,9 +110,27 @@ function ForwardButton({ children, ...props }: ComponentProps<'button'>) {
     pageForward();
   };
   return (
-    <button type="button" onClick={onClick} {...props}>
-      {children}
-    </button>
+    <>
+      <button type="button" onClick={onClick} {...props}>
+        {children}
+      </button>
+      <style jsx>
+        {`
+          button {
+            background-color: var(--accent-color);
+            padding: 12px 48px;
+            border-radius: 4px;
+            border: 0;
+            color: #ffffff;
+            font-weight: 700;
+          }
+          button:disabled {
+            background-color: #b1d9f0;
+            cursor: not-allowed;
+          }
+        `}
+      </style>
+    </>
   );
 }
 
@@ -126,9 +144,21 @@ function BackButton({ children, ...props }: ComponentProps<'button'>) {
     pageBack();
   };
   return (
-    <button onClick={onClick} {...props}>
-      {children}
-    </button>
+    <>
+      <button onClick={onClick} {...props}>
+        {children}
+      </button>
+      <style jsx>{`
+        button {
+          border: 1px solid var(--accent-color);
+          padding: 12px 48px;
+          border-radius: 4px;
+          color: var(--accent-color);
+          background-color: #ffffff;
+          font-weight: 700;
+        }
+      `}</style>
+    </>
   );
 }
 

--- a/components/OrderedPages.tsx
+++ b/components/OrderedPages.tsx
@@ -56,6 +56,8 @@ function recursiveMap(
         children: recursiveMap(child.props.children, callback),
       });
     }
+
+    return child;
   });
 }
 
@@ -130,30 +132,4 @@ function BackButton({ children, ...props }: ComponentProps<'button'>) {
   );
 }
 
-function Indicator() {
-  const { pageCount, activeIndex } = useOrderedPages();
-
-  const pageIndices = Array.from(Array(pageCount).keys());
-  const indices = pageIndices.map((index) => (
-    <Fragment key={index}>
-      <span>・</span>
-      <style jsx>{`
-        span {
-          font-size: 1.6rem;
-          color: ${index === activeIndex ? 'tomato' : 'black'};
-        }
-      `}</style>
-    </Fragment>
-  ));
-
-  return <>{indices}</>;
-}
-
-export {
-  OrderedPages,
-  Page,
-  ForwardButton,
-  BackButton,
-  useOrderedPages,
-  Indicator,
-};
+export { OrderedPages, Page, ForwardButton, BackButton, useOrderedPages };

--- a/components/OrderedPages.tsx
+++ b/components/OrderedPages.tsx
@@ -1,5 +1,10 @@
 import { Children, createContext, Fragment, useContext, useState } from 'react';
-import type { ReactNode, ReactElement } from 'react';
+import type {
+  ComponentProps,
+  MouseEvent,
+  ReactNode,
+  ReactElement,
+} from 'react';
 
 type WrapperProps = {
   children: ReactElement | ReactElement[];
@@ -68,14 +73,36 @@ function Page({ children }: PageProps) {
   return <>{children}</>;
 }
 
-function ForwardButton({ children }: { children: ReactNode }) {
+function ForwardButton({ children, ...props }: ComponentProps<'button'>) {
   const { pageForward } = useOrderedPages();
-  return <button onClick={pageForward}>{children}</button>;
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (props.onClick) {
+      props.onClick(e);
+    }
+    pageForward();
+  };
+  return (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  );
 }
 
-function BackButton({ children }: { children: ReactNode }) {
+function BackButton({ children, ...props }: ComponentProps<'button'>) {
   const { pageBack } = useOrderedPages();
-  return <button onClick={pageBack}>{children}</button>;
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (props.onClick) {
+      props.onClick(e);
+    }
+    pageBack();
+  };
+  return (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  );
 }
 
 function Indicator() {

--- a/components/applicationForm/Completed.tsx
+++ b/components/applicationForm/Completed.tsx
@@ -1,14 +1,18 @@
 function Completed() {
   return (
     <div className="completed-message">
-      <p>募集主に連絡を送りました。</p>
+      <p className="head-message">募集主に連絡を送りました。</p>
       <p>
         募集主からあなたのメールアドレス宛に連絡が届くまでしばらくお待ちください
       </p>
       <style jsx>{`
         .completed-message {
-          margin-top: 24px;
           text-align: center;
+        }
+        .head-message {
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 20px;
         }
         .completed-message p {
           margin-bottom: 12px;

--- a/components/applicationForm/Indicator.tsx
+++ b/components/applicationForm/Indicator.tsx
@@ -1,0 +1,33 @@
+import { Fragment } from 'react';
+import { useOrderedPages } from '../OrderedPages';
+
+function Indicator() {
+  const { pageCount, activeIndex } = useOrderedPages();
+
+  // 完了モーダルはIndicatorの数に含めない
+  const indicatorCount = pageCount - 1;
+  const indicators = Array.from(Array(indicatorCount).keys());
+
+  const activeIndicator = Math.min(activeIndex, indicatorCount - 1);
+  console.log(activeIndicator);
+
+  const indices = indicators.map((index) => (
+    <Fragment key={index}>
+      <svg height="8" width="8">
+        <circle cx="4" cy="4" r="4" />
+      </svg>
+      <style jsx>{`
+        svg {
+          fill: ${index === activeIndicator
+            ? 'var(--accent-color)'
+            : '#cdcdcd'};
+          margin-right: 16px;
+        }
+      `}</style>
+    </Fragment>
+  ));
+
+  return <>{indices}</>;
+}
+
+export default Indicator;

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -1,18 +1,22 @@
-import { ForwardButton, useOrderedPages } from '../OrderedPages';
+import { useOrderedPages } from '../OrderedPages';
 
 const INTEREST_LEVELS = {
-  HIGH: 3,
+  HIGH: 1,
   MIDDLE: 2,
-  LOW: 1,
+  LOW: 3,
 };
 
-function InterestLevel() {
+type Props = {
+  interest: number | null;
+  setInterest: (n: number) => void;
+};
+
+function InterestLevel({ interest, setInterest }: Props) {
   const { pageForward } = useOrderedPages();
 
   const handleInterestSelected = (fn: () => void) => {
     return () => {
       fn();
-      pageForward();
     };
   };
 
@@ -28,24 +32,36 @@ function InterestLevel() {
     setInterest(INTEREST_LEVELS.LOW);
   });
 
-  // フェイク
-  const setInterest = (interest: number) => {
-    return;
-  };
-
   return (
     <>
       <div className="interest-selector">
         <p className="instruction">この募集にどのくらい興味がありますか？</p>
-        <button onClick={onHighSelected}>是非参加したい</button>
+        <button
+          className={`interest-option ${interest === 1 ? 'selected' : ''}`}
+          onClick={onHighSelected}
+        >
+          是非参加したい
+        </button>
         <br />
-        <button onClick={onMiddleSelected}>内容によっては参加したい</button>
+        <button
+          className={`interest-option ${interest === 2 ? 'selected' : ''}`}
+          onClick={onMiddleSelected}
+        >
+          内容によっては参加したい
+        </button>
         <br />
-        <button onClick={onLowSelected}>とりあえず話してみたい</button>
+        <button
+          className={`interest-option ${interest === 3 ? 'selected' : ''}`}
+          onClick={onLowSelected}
+        >
+          とりあえず話してみたい
+        </button>
       </div>
-      {/* <div className="page-controller">
-        <ForwardButton>進む →</ForwardButton>
-      </div> */}
+      <div className="page-controller">
+        <button onClick={() => pageForward()} disabled={interest === null}>
+          進む →
+        </button>
+      </div>
       <style jsx>{`
         .instruction {
           margin-bottom: 16px;
@@ -57,14 +73,21 @@ function InterestLevel() {
         .interest-selector button {
           padding: 16px 32px;
           border-radius: 28px;
+          font-weight: 800;
+          margin-bottom: 12px;
+          background-color: #ffffff;
+          border: 1px solid #25a5ec;
+          color: #25a5ec;
+        }
+        .interest-selector button.selected {
+          padding: 16px 32px;
+          border-radius: 28px;
           border: 0;
           color: #ffffff;
           background-color: #25a5ec;
-          font-weight: 800;
-          margin-bottom: 12px;
         }
-        button:hover {
-          background-color: #36b3f7;
+        .interest-selector button:hover {
+          cursor: pointer;
         }
         .page-controller {
           text-align: center;

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -1,4 +1,4 @@
-import { useOrderedPages } from '../OrderedPages';
+import { ForwardButton } from '../OrderedPages';
 
 const INTEREST_LEVELS = {
   HIGH: 1,
@@ -12,8 +12,6 @@ type Props = {
 };
 
 function InterestLevel({ interest, setInterest }: Props) {
-  const { pageForward } = useOrderedPages();
-
   const handleInterestSelected = (fn: () => void) => {
     return () => {
       fn();
@@ -58,9 +56,7 @@ function InterestLevel({ interest, setInterest }: Props) {
         </button>
       </div>
       <div className="page-controller">
-        <button onClick={() => pageForward()} disabled={interest === null}>
-          進む →
-        </button>
+        <ForwardButton disabled={interest === null}>次へ</ForwardButton>
       </div>
       <style jsx>{`
         .instruction {

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -30,7 +30,7 @@ function InterestLevel() {
   return (
     <>
       <div className="interest-selector">
-        <p className="instruction">この募集にどのくらい興味がありますか？</p>
+        <p className="instruction">現在の興味度を選択してください</p>
         <button
           type="button"
           className={`interest-option ${interest === 1 ? 'selected' : ''}`}
@@ -60,7 +60,9 @@ function InterestLevel() {
       </div>
       <style jsx>{`
         .instruction {
-          margin-bottom: 16px;
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 20px;
         }
         .interest-selector {
           text-align: center;

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -1,4 +1,5 @@
 import { ForwardButton } from '../OrderedPages';
+import { useApplyFormContext } from '.';
 
 const INTEREST_LEVELS = {
   HIGH: 1,
@@ -6,12 +7,8 @@ const INTEREST_LEVELS = {
   LOW: 3,
 };
 
-type Props = {
-  interest: number | null;
-  setInterest: (n: number) => void;
-};
-
-function InterestLevel({ interest, setInterest }: Props) {
+function InterestLevel() {
+  const { interest, setInterest } = useApplyFormContext();
   const handleInterestSelected = (fn: () => void) => {
     return () => {
       fn();
@@ -35,6 +32,7 @@ function InterestLevel({ interest, setInterest }: Props) {
       <div className="interest-selector">
         <p className="instruction">この募集にどのくらい興味がありますか？</p>
         <button
+          type="button"
           className={`interest-option ${interest === 1 ? 'selected' : ''}`}
           onClick={onHighSelected}
         >
@@ -42,6 +40,7 @@ function InterestLevel({ interest, setInterest }: Props) {
         </button>
         <br />
         <button
+          type="button"
           className={`interest-option ${interest === 2 ? 'selected' : ''}`}
           onClick={onMiddleSelected}
         >
@@ -49,6 +48,7 @@ function InterestLevel({ interest, setInterest }: Props) {
         </button>
         <br />
         <button
+          type="button"
           className={`interest-option ${interest === 3 ? 'selected' : ''}`}
           onClick={onLowSelected}
         >

--- a/components/applicationForm/Message.tsx
+++ b/components/applicationForm/Message.tsx
@@ -1,21 +1,12 @@
 import { ChangeEvent } from 'react';
-import { BackButton, useOrderedPages } from '../OrderedPages';
+import { BackButton } from '../OrderedPages';
+import { useApplyFormContext } from '.';
 
-type Props = {
-  message: string;
-  setMessage: (s: string) => void;
-  onSubmit: () => void;
-};
+function Message() {
+  const { message, setMessage } = useApplyFormContext();
 
-function Message({ message, setMessage, onSubmit }: Props) {
-  const { pageForward } = useOrderedPages();
   const onMessageChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setMessage(e.target.value);
-  };
-
-  const handleSubmit = () => {
-    onSubmit();
-    pageForward();
   };
 
   return (
@@ -34,7 +25,7 @@ function Message({ message, setMessage, onSubmit }: Props) {
       </div>
       <div className="page-controller">
         <BackButton>← 戻る</BackButton>
-        <button onClick={handleSubmit}>送信</button>
+        <button type="submit">送信</button>
       </div>
       <style jsx>{`
         .instruction {

--- a/components/applicationForm/Message.tsx
+++ b/components/applicationForm/Message.tsx
@@ -20,16 +20,18 @@ function Message() {
           name="message"
           onChange={onMessageChange}
           value={message}
-          aria-label="募集主へのメッセージ"
+          aria-label="募集主に伝えたいこと"
         ></textarea>
       </div>
       <div className="page-controller">
-        <BackButton>← 戻る</BackButton>
+        <BackButton>戻る</BackButton>
         <button type="submit">送信</button>
       </div>
       <style jsx>{`
         .instruction {
-          margin-bottom: 4px;
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 20px;
         }
         .message_wrapper {
           text-align: center;
@@ -40,6 +42,8 @@ function Message() {
           padding: 8px;
           max-width: 420px;
           margin-bottom: 24px;
+          border-radius: 4px;
+          border: 1px solid #cdcdcd;
         }
         .page-controller {
           display: flex;
@@ -47,12 +51,12 @@ function Message() {
           justify-content: space-evenly;
         }
         .page-controller button {
-          border-radius: 8px;
+          border-radius: 4px;
           border: 0;
-          padding: 8px 24px;
+          padding: 12px 48px;
           color: #ffffff;
-          background-color: #25a5ec;
-          font-weight: 800;
+          background-color: var(--accent-color);
+          font-weight: 700;
         }
         .page-controller button:hover {
           background-color: #36b3f7;

--- a/components/applicationForm/Message.tsx
+++ b/components/applicationForm/Message.tsx
@@ -1,19 +1,21 @@
 import { ChangeEvent } from 'react';
 import { BackButton, useOrderedPages } from '../OrderedPages';
-function Message() {
+
+type Props = {
+  message: string;
+  setMessage: (s: string) => void;
+  onSubmit: () => void;
+};
+
+function Message({ message, setMessage, onSubmit }: Props) {
   const { pageForward } = useOrderedPages();
   const onMessageChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setMessage(e.target.value);
   };
 
-  const onSubmit = () => {
-    // TODO: API呼ぶ
+  const handleSubmit = () => {
+    onSubmit();
     pageForward();
-  };
-
-  // フェイク
-  const setMessage = (message: string) => {
-    return;
   };
 
   return (
@@ -26,12 +28,13 @@ function Message() {
           id="message"
           name="message"
           onChange={onMessageChange}
+          value={message}
           aria-label="募集主へのメッセージ"
         ></textarea>
       </div>
       <div className="page-controller">
         <BackButton>← 戻る</BackButton>
-        <button onClick={onSubmit}>送信</button>
+        <button onClick={handleSubmit}>送信</button>
       </div>
       <style jsx>{`
         .instruction {

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -11,14 +11,14 @@ function UserClass() {
   return (
     <>
       <div className="user_class_wrapper">
-        <label htmlFor="user_class">自分のクラス</label>
-        <br />
+        <p className="instruction">自分のクラスを入力してください</p>
         <input
           id="user_class"
           type="text"
           value={userClass}
           name="user_class"
           onChange={onChangeUserClass}
+          aria-label="自分のクラス"
         />
         <p className="note">
           募集主はあなたの所属するクラスを知ることができます
@@ -26,19 +26,26 @@ function UserClass() {
       </div>
       <div className="page-controller">
         <BackButton>戻る</BackButton>
-        <ForwardButton disabled={userClass.length === 0}>進む</ForwardButton>
+        <ForwardButton disabled={userClass.length === 0}>次へ</ForwardButton>
       </div>
       <style jsx>{`
         .user_class_wrapper {
           text-align: center;
           margin-bottom: 24px;
         }
+        .instruction {
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 48px;
+        }
         input {
           font-size: 1.1rem;
-          width: 120px;
-          padding: 4px 8px;
+          width: 60%;
+          padding: 12px 16px;
           margin-top: 4px;
-          margin-bottom: 24px;
+          margin-bottom: 18px;
+          border-radius: 4px;
+          border: 1px solid #cdcdcd;
         }
         .note {
           font-size: 0.8rem;

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -1,12 +1,9 @@
 import type { ChangeEvent } from 'react';
 import { ForwardButton, BackButton } from '../OrderedPages';
+import { useApplyFormContext } from '.';
 
-type Props = {
-  userClass: string;
-  setUserClass: (s: string) => void;
-};
-
-function UserClass({ userClass, setUserClass }: Props) {
+function UserClass() {
+  const { userClass, setUserClass } = useApplyFormContext();
   const onChangeUserClass = (e: ChangeEvent<HTMLInputElement>) => {
     setUserClass(e.target.value);
   };

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import { ForwardButton, BackButton, useOrderedPages } from '../OrderedPages';
+import { ForwardButton, BackButton } from '../OrderedPages';
 
 type Props = {
   userClass: string;
@@ -7,7 +7,6 @@ type Props = {
 };
 
 function UserClass({ userClass, setUserClass }: Props) {
-  const { pageForward } = useOrderedPages();
   const onChangeUserClass = (e: ChangeEvent<HTMLInputElement>) => {
     setUserClass(e.target.value);
   };
@@ -29,10 +28,8 @@ function UserClass({ userClass, setUserClass }: Props) {
         </p>
       </div>
       <div className="page-controller">
-        <BackButton>← 戻る</BackButton>
-        <button onClick={() => pageForward()} disabled={userClass.length === 0}>
-          進む →
-        </button>
+        <BackButton>戻る</BackButton>
+        <ForwardButton disabled={userClass.length === 0}>進む</ForwardButton>
       </div>
       <style jsx>{`
         .user_class_wrapper {

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -1,14 +1,15 @@
 import type { ChangeEvent } from 'react';
-import { ForwardButton, BackButton } from '../OrderedPages';
+import { ForwardButton, BackButton, useOrderedPages } from '../OrderedPages';
 
-function UserClass() {
+type Props = {
+  userClass: string;
+  setUserClass: (s: string) => void;
+};
+
+function UserClass({ userClass, setUserClass }: Props) {
+  const { pageForward } = useOrderedPages();
   const onChangeUserClass = (e: ChangeEvent<HTMLInputElement>) => {
     setUserClass(e.target.value);
-  };
-
-  // フェイク
-  const setUserClass = (userClass: string) => {
-    return;
   };
 
   return (
@@ -19,6 +20,7 @@ function UserClass() {
         <input
           id="user_class"
           type="text"
+          value={userClass}
           name="user_class"
           onChange={onChangeUserClass}
         />
@@ -28,7 +30,9 @@ function UserClass() {
       </div>
       <div className="page-controller">
         <BackButton>← 戻る</BackButton>
-        <ForwardButton>進む →</ForwardButton>
+        <button onClick={() => pageForward()} disabled={userClass.length === 0}>
+          進む →
+        </button>
       </div>
       <style jsx>{`
         .user_class_wrapper {

--- a/components/applicationForm/index.tsx
+++ b/components/applicationForm/index.tsx
@@ -1,10 +1,29 @@
+import { useState } from 'react';
+import { useApplyOffer } from '../../hooks/requests/offers';
 import { OrderedPages, Page, Indicator } from '../OrderedPages';
 import Completed from './Completed';
 import InterestLevel from './InterestLevel';
 import Message from './Message';
 import UserClass from './UserClass';
 
-function ApplicationForm() {
+type Props = {
+  offerId: number;
+};
+
+function ApplicationForm({ offerId }: Props) {
+  const { mutate } = useApplyOffer();
+  const [interest, setInterest] = useState<number | null>(null);
+  const [userClass, setUserClass] = useState('');
+  const [message, setMessage] = useState('');
+
+  const onSubmit = () => {
+    mutate({
+      offer_id: offerId,
+      interest: interest || 1,
+      user_class: userClass,
+      message,
+    });
+  };
   return (
     <div role="form" aria-label="募集主に連絡をとる">
       <OrderedPages>
@@ -12,19 +31,23 @@ function ApplicationForm() {
           <div className="indicator">
             <Indicator />
           </div>
-          <InterestLevel />
+          <InterestLevel interest={interest} setInterest={setInterest} />
         </Page>
         <Page>
           <div className="indicator">
             <Indicator />
           </div>
-          <UserClass />
+          <UserClass userClass={userClass} setUserClass={setUserClass} />
         </Page>
         <Page>
           <div className="indicator">
             <Indicator />
           </div>
-          <Message />
+          <Message
+            message={message}
+            setMessage={setMessage}
+            onSubmit={onSubmit}
+          />
         </Page>
         <Page>
           <Completed />

--- a/components/applicationForm/index.tsx
+++ b/components/applicationForm/index.tsx
@@ -36,7 +36,7 @@ type PagedApplyFormProps = {
 
 function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
   const { pageForward } = useOrderedPages();
-  const { mutate } = useApplyOffer();
+  const { mutate, isLoading, isError } = useApplyOffer();
   const [interest, setInterest] = useState<number | null>(null);
   const [userClass, setUserClass] = useState('');
   const [message, setMessage] = useState('');
@@ -58,6 +58,8 @@ function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
     );
   };
 
+  console.log(isLoading);
+
   return (
     <ApplyFormContext.Provider
       value={{
@@ -70,6 +72,23 @@ function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
       }}
     >
       <form onSubmit={onSubmit}>{children}</form>
+      {isLoading && <p className="message load">データを送信中...</p>}
+      {isError && (
+        <p className="message error">
+          データの送信に失敗しました。しばらくしてから再度送信してください。
+        </p>
+      )}
+      <style jsx>{`
+        .message {
+          margin-top: 12px;
+          text-align: center;
+        }
+        .message.error {
+          margin-top: 12px;
+          text-align: center;
+          color: #ff0000;
+        }
+      `}</style>
     </ApplyFormContext.Provider>
   );
 }

--- a/components/applicationForm/index.tsx
+++ b/components/applicationForm/index.tsx
@@ -2,12 +2,13 @@ import { createContext, useContext, useState } from 'react';
 import type { Dispatch, MouseEvent, ReactNode, SetStateAction } from 'react';
 import { useApplyOffer } from '../../hooks/requests/offers';
 import {
+  ForwardButton,
   OrderedPages,
   Page,
-  Indicator,
   useOrderedPages,
 } from '../OrderedPages';
 import Completed from './Completed';
+import Indicator from './Indicator';
 import InterestLevel from './InterestLevel';
 import Message from './Message';
 import UserClass from './UserClass';
@@ -43,22 +44,21 @@ function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
 
   const onSubmit = (e: MouseEvent<HTMLFormElement>) => {
     e.preventDefault();
-    mutate(
-      {
-        offer_id: offerId,
-        interest: interest || 1,
-        user_class: userClass,
-        message,
-      },
-      {
-        onSuccess() {
-          pageForward();
-        },
-      }
-    );
+    // mutate(
+    //   {
+    //     offer_id: offerId,
+    //     interest: interest || 1,
+    //     user_class: userClass,
+    //     message,
+    //   },
+    //   {
+    //     onSuccess() {
+    //       pageForward();
+    //     },
+    //   }
+    // );
+    pageForward();
   };
-
-  console.log(isLoading);
 
   return (
     <ApplyFormContext.Provider
@@ -100,29 +100,29 @@ type ApplyFormProps = {
 function ApplyForm({ offerId }: ApplyFormProps) {
   return (
     <OrderedPages>
+      <div className="indicator">
+        <Indicator />
+      </div>
       <PagedApplyForm offerId={offerId}>
         <Page>
-          <div className="indicator">
-            <Indicator />
-          </div>
           <InterestLevel />
         </Page>
         <Page>
-          <div className="indicator">
-            <Indicator />
-          </div>
           <UserClass />
         </Page>
         <Page>
-          <div className="indicator">
-            <Indicator />
-          </div>
           <Message />
         </Page>
         <Page>
           <Completed />
         </Page>
       </PagedApplyForm>
+      <style jsx>{`
+        .indicator {
+          text-align: center;
+          margin-bottom: 12px;
+        }
+      `}</style>
     </OrderedPages>
   );
 }

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -36,6 +36,14 @@ type GetOfferResponse = {
   offer: Offer;
 };
 
+type ApplyRequest = {
+  offer_id: number;
+  interest: number;
+  user_class: string;
+  message: string;
+};
+type ApplyResponse = void;
+
 type AddOfferRequest = {
   title: string;
   target: string;
@@ -110,13 +118,32 @@ function useOffer({ offer_id }: GetOfferRequest, enabled = true) {
   );
 }
 
+function useApplyOffer() {
+  return useMutation<ApplyResponse, Error, ApplyRequest>((options) => {
+    return jsonClient(API_HOST + '/offer/apply', {
+      method: 'POST',
+      body: { ...options },
+    });
+  });
+}
+
 function useAddOffer() {
   const queryClient = useQueryClient();
   return useMutation<AddOfferResponse, Error, AddOfferRequest>(
     (newOffer) => {
+      const m = (new Date(newOffer.end_date).getMonth() + 1).toString();
+      const d = new Date(newOffer.end_date).getDate().toString();
+
+      const ymd =
+        new Date(newOffer.end_date).getFullYear() +
+        '-' +
+        (m.length === 1 ? '0' + m : m) +
+        '-' +
+        (d.length === 1 ? '0' + d : d);
+
       return jsonClient(API_HOST + '/offer/post', {
         method: 'POST',
-        body: { ...newOffer },
+        body: { ...newOffer, picture: null, end_date: ymd },
       });
     },
     {
@@ -173,6 +200,7 @@ function useUserOffers(
 
 export type { Offer };
 export {
+  useApplyOffer,
   useAddOffer,
   useEditOffer,
   useInfiniteOffers,

--- a/pages/board/offers/[offerId].tsx
+++ b/pages/board/offers/[offerId].tsx
@@ -91,7 +91,7 @@ function OfferDetailPage() {
             <div className="modal-header">
               <button onClick={() => setShowModal(false)}>X</button>
             </div>
-            <ApplicationForm />
+            <ApplicationForm offerId={offer.id} />
           </Modal>
         </div>
       )}


### PR DESCRIPTION
## 概要
応募モーダルで応募ができるようにしました

## メモ
- OrderedPagesコンポーネントをやめてreact-tabsで代用しようとすると、できはするけど`<Tab />`を使わずに`<TabPanel />`を使うと警告が出るみたいなので、正規の使い方じゃなさそうだった。なのでOrderedPagesの直下にPage以外の子要素も持てるようにして、react-tabsっぽく使えるように変更した。これによってOrderedPages直下のコンポーネントでページの切り替わりのタイミングを制御できるようになったので、応募を送信し終わるまで完了モーダルを表示しないようにできた。
- Indicatorはモーダルによって要件が大きく変わる気がするのでOrderedPagesの一部として提供する意味がないように思った。そのためIndicatorをApplyFormの一部として作り直した。