### PR TITLE
Fix 投稿ボタンの+アイコンが表示されてなかったバグ

### DIFF
--- a/public/plus.svg
+++ b/public/plus.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 10.2857H10.2857V18H7.71429V10.2857H0V7.71429H7.71429V0H10.2857V7.71429H18V10.2857Z" fill="white"/>
+</svg>


### PR DESCRIPTION
## 概要
募集一覧ページで投稿ボタンの+アイコンのアセットを追加し忘れていたので追加しました。