### PR TITLE
Add ユーザー編集画面にログイン済みユーザーのデータを表示

### DIFF
--- a/pages/user/edit/email.tsx
+++ b/pages/user/edit/email.tsx
@@ -4,10 +4,13 @@ import type { ReactElement } from 'react';
 import Modal from 'react-modal';
 import Layout from '../../../components/layouts/Layout';
 import { useEmailForm } from '../../../hooks/forms/useEmailForm';
+import { useLoginUser } from '../../../hooks/requests/auth';
 import { useEditEmail } from '../../../hooks/requests/profile';
-import { user } from '../../../mocks/handlers/auth';
 
 function EditEmailPage() {
+  const { data } = useLoginUser();
+  const user = data?.user;
+
   const [showModal, setShowModal] = useState(false);
   const {
     register,
@@ -29,11 +32,11 @@ function EditEmailPage() {
   });
   const handleCancel = () => {
     if (confirm('入力内容を破棄しますか?')) {
-      router.push(`/user/${user.student_number}`);
+      router.push(`/user/${user?.student_number}`);
     }
   };
   const handleDone = () => {
-    router.push(`/user/${user.student_number}`);
+    router.push(`/user/${user?.student_number}`);
   };
 
   return (

--- a/pages/user/edit/profile.tsx
+++ b/pages/user/edit/profile.tsx
@@ -2,10 +2,13 @@ import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../../components/layouts/Layout';
 import { useProfileForm } from '../../../hooks/forms/useProfileForm';
+import { useLoginUser } from '../../../hooks/requests/auth';
 import { useEditUser } from '../../../hooks/requests/profile';
-import { user } from '../../../mocks/handlers/auth';
 
 function EditProfilePage() {
+  const { data } = useLoginUser();
+  const user = data?.user;
+
   const {
     register,
     handleSubmit,
@@ -19,14 +22,14 @@ function EditProfilePage() {
   const onSubmit = handleSubmit((data) => {
     mutate(data, {
       onSuccess: () => {
-        router.push(`/user/${user.student_number}`);
+        router.push(`/user/${user?.student_number}`);
       },
     });
   });
 
   const handleCancel = () => {
     if (confirm('入力内容を破棄しますか?')) {
-      router.push(`/user/${user.student_number}`);
+      router.push(`/user/${user?.student_number}`);
     }
   };
 


### PR DESCRIPTION
## 概要
メールアドレス変更画面とプロフィール編集画面のフォームに初期表示するデータがダミーデータのままだったので、ログインしたユーザーの情報を表示するように変更しました。