### PR TITLE
Add E展で見せるための機能

### DIFF
--- a/components/OfferOverview.tsx
+++ b/components/OfferOverview.tsx
@@ -57,7 +57,7 @@ export default function OfferOverview({ offer, editable = false }: Props) {
           <a className="title">{offer.title}</a>
         </Link>
       </h2>
-      <p className="note">{offer.note || 'なし'}</p>
+      <p className="note">{getShortNote(offer.note || 'なし')}</p>
       <div className="info">
         <div
           className="user-info"
@@ -185,4 +185,12 @@ function getDaysBeforeExpiration(date: Date) {
 
   // 今日の24時になった瞬間（日付が変わった瞬間)消えるなら「残り0日」
   return Math.floor(diffInMs / (1000 * 60 * 60 * 24));
+}
+
+function getShortNote(note: string) {
+  if (note.length <= 70) {
+    return note;
+  }
+
+  return note.slice(0, 70) + '...';
 }

--- a/components/OfferOverview.tsx
+++ b/components/OfferOverview.tsx
@@ -136,7 +136,7 @@ export default function OfferOverview({ offer, editable = false }: Props) {
           width: 45px;
           height: 45px;
           margin-right: 6px;
-          clip-path: circle(50%);
+          border-radius: 50%;
           background-color: #707070;
         }
         .user-class {

--- a/components/OfferOverview.tsx
+++ b/components/OfferOverview.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import type { Offer } from '../hooks/requests/offers';
 
 type Props = {
@@ -17,10 +17,6 @@ export default function OfferOverview({ offer, editable = false }: Props) {
   const router = useRouter();
 
   const firstTagName = offer.tags[0].name;
-  const randomIconSize = useMemo(
-    () => Math.floor(Math.random() * (300 + 1 - 200)) + 200,
-    []
-  );
 
   return (
     <div className="offer-overview">
@@ -47,7 +43,15 @@ export default function OfferOverview({ offer, editable = false }: Props) {
           ) : null}
         </div>
       )}
-      <div className="offer-image">{firstTagName}</div>
+      {offer.picture ? (
+        <img
+          alt="ユーザーが投稿した画像"
+          src={offer.picture}
+          className="offer-image"
+        ></img>
+      ) : (
+        <div className="offer-image">{firstTagName}</div>
+      )}
       <h2>
         <Link href={`/board/offers/${offer.id}`}>
           <a className="title">{offer.title}</a>
@@ -55,12 +59,13 @@ export default function OfferOverview({ offer, editable = false }: Props) {
       </h2>
       <p className="note">{offer.note || 'なし'}</p>
       <div className="info">
-        <div className="user-info">
-          <img
-            alt="募集主のアイコン"
-            src={`https://placeimg.com/${randomIconSize}/${randomIconSize}/nature`}
-            className="user-icon"
-          ></img>
+        <div
+          className="user-info"
+          onClick={() => {
+            router.push(`/user/${offer.student_number}`);
+          }}
+        >
+          <div className="user-icon"></div>
           <div>
             <div>
               <span className="user-class">{offer.user_class || ''}</span>
@@ -85,8 +90,7 @@ export default function OfferOverview({ offer, editable = false }: Props) {
       </div>
       <style jsx>{`
         .offer-overview {
-          width: 30%;
-          min-width: 250px;
+          width: 320px;
           margin: 4px;
           padding: 8px;
           color: var(--black-900);
@@ -124,11 +128,16 @@ export default function OfferOverview({ offer, editable = false }: Props) {
           display: flex;
           align-items: flex-end;
         }
+        .user-info:hover {
+          font-weight: 900;
+          cursor: pointer;
+        }
         .user-icon {
           width: 45px;
           height: 45px;
           margin-right: 6px;
           clip-path: circle(50%);
+          background-color: #707070;
         }
         .user-class {
           margin-right: 8px;

--- a/components/OfferOverview.tsx
+++ b/components/OfferOverview.tsx
@@ -43,20 +43,20 @@ export default function OfferOverview({ offer, editable = false }: Props) {
           ) : null}
         </div>
       )}
-      {offer.picture ? (
-        <img
-          alt="ユーザーが投稿した画像"
-          src={offer.picture}
-          className="offer-image"
-        ></img>
-      ) : (
-        <div className="offer-image">{firstTagName}</div>
-      )}
-      <h2>
-        <Link href={`/board/offers/${offer.id}`}>
-          <a className="title">{offer.title}</a>
-        </Link>
-      </h2>
+      <Link href={`/board/offers/${offer.id}`}>
+        <a className="detail-page-link">
+          {offer.picture ? (
+            <img
+              alt="ユーザーが投稿した画像"
+              src={offer.picture}
+              className="offer-image"
+            ></img>
+          ) : (
+            <div className="offer-image">{firstTagName}</div>
+          )}
+          <h2 className="title">{offer.title}</h2>
+        </a>
+      </Link>
       <p className="note">{getShortNote(offer.note || 'なし')}</p>
       <div className="info">
         <div
@@ -109,10 +109,12 @@ export default function OfferOverview({ offer, editable = false }: Props) {
           color: #ffffff;
           margin-bottom: 12px;
         }
+        .detail-page-link {
+          text-decoration: none;
+        }
         .title {
           color: var(--black-900);
           font-size: 1.2rem;
-          text-decoration: none;
           margin-bottom: 6px;
         }
         .note {

--- a/components/OrderedPages.tsx
+++ b/components/OrderedPages.tsx
@@ -110,9 +110,27 @@ function ForwardButton({ children, ...props }: ComponentProps<'button'>) {
     pageForward();
   };
   return (
-    <button type="button" onClick={onClick} {...props}>
-      {children}
-    </button>
+    <>
+      <button type="button" onClick={onClick} {...props}>
+        {children}
+      </button>
+      <style jsx>
+        {`
+          button {
+            background-color: var(--accent-color);
+            padding: 12px 48px;
+            border-radius: 4px;
+            border: 0;
+            color: #ffffff;
+            font-weight: 700;
+          }
+          button:disabled {
+            background-color: #b1d9f0;
+            cursor: not-allowed;
+          }
+        `}
+      </style>
+    </>
   );
 }
 
@@ -126,9 +144,21 @@ function BackButton({ children, ...props }: ComponentProps<'button'>) {
     pageBack();
   };
   return (
-    <button onClick={onClick} {...props}>
-      {children}
-    </button>
+    <>
+      <button onClick={onClick} {...props}>
+        {children}
+      </button>
+      <style jsx>{`
+        button {
+          border: 1px solid var(--accent-color);
+          padding: 12px 48px;
+          border-radius: 4px;
+          color: var(--accent-color);
+          background-color: #ffffff;
+          font-weight: 700;
+        }
+      `}</style>
+    </>
   );
 }
 

--- a/components/OrderedPages.tsx
+++ b/components/OrderedPages.tsx
@@ -56,6 +56,8 @@ function recursiveMap(
         children: recursiveMap(child.props.children, callback),
       });
     }
+
+    return child;
   });
 }
 
@@ -130,30 +132,4 @@ function BackButton({ children, ...props }: ComponentProps<'button'>) {
   );
 }
 
-function Indicator() {
-  const { pageCount, activeIndex } = useOrderedPages();
-
-  const pageIndices = Array.from(Array(pageCount).keys());
-  const indices = pageIndices.map((index) => (
-    <Fragment key={index}>
-      <span>・</span>
-      <style jsx>{`
-        span {
-          font-size: 1.6rem;
-          color: ${index === activeIndex ? 'tomato' : 'black'};
-        }
-      `}</style>
-    </Fragment>
-  ));
-
-  return <>{indices}</>;
-}
-
-export {
-  OrderedPages,
-  Page,
-  ForwardButton,
-  BackButton,
-  useOrderedPages,
-  Indicator,
-};
+export { OrderedPages, Page, ForwardButton, BackButton, useOrderedPages };

--- a/components/OrderedPages.tsx
+++ b/components/OrderedPages.tsx
@@ -1,5 +1,10 @@
 import { Children, createContext, Fragment, useContext, useState } from 'react';
-import type { ReactNode, ReactElement } from 'react';
+import type {
+  ComponentProps,
+  MouseEvent,
+  ReactNode,
+  ReactElement,
+} from 'react';
 
 type WrapperProps = {
   children: ReactElement | ReactElement[];
@@ -68,14 +73,36 @@ function Page({ children }: PageProps) {
   return <>{children}</>;
 }
 
-function ForwardButton({ children }: { children: ReactNode }) {
+function ForwardButton({ children, ...props }: ComponentProps<'button'>) {
   const { pageForward } = useOrderedPages();
-  return <button onClick={pageForward}>{children}</button>;
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (props.onClick) {
+      props.onClick(e);
+    }
+    pageForward();
+  };
+  return (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  );
 }
 
-function BackButton({ children }: { children: ReactNode }) {
+function BackButton({ children, ...props }: ComponentProps<'button'>) {
   const { pageBack } = useOrderedPages();
-  return <button onClick={pageBack}>{children}</button>;
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (props.onClick) {
+      props.onClick(e);
+    }
+    pageBack();
+  };
+  return (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  );
 }
 
 function Indicator() {

--- a/components/applicationForm/Completed.tsx
+++ b/components/applicationForm/Completed.tsx
@@ -1,14 +1,18 @@
 function Completed() {
   return (
     <div className="completed-message">
-      <p>募集主に連絡を送りました。</p>
+      <p className="head-message">募集主に連絡を送りました。</p>
       <p>
         募集主からあなたのメールアドレス宛に連絡が届くまでしばらくお待ちください
       </p>
       <style jsx>{`
         .completed-message {
-          margin-top: 24px;
           text-align: center;
+        }
+        .head-message {
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 20px;
         }
         .completed-message p {
           margin-bottom: 12px;

--- a/components/applicationForm/Indicator.tsx
+++ b/components/applicationForm/Indicator.tsx
@@ -1,0 +1,33 @@
+import { Fragment } from 'react';
+import { useOrderedPages } from '../OrderedPages';
+
+function Indicator() {
+  const { pageCount, activeIndex } = useOrderedPages();
+
+  // 完了モーダルはIndicatorの数に含めない
+  const indicatorCount = pageCount - 1;
+  const indicators = Array.from(Array(indicatorCount).keys());
+
+  const activeIndicator = Math.min(activeIndex, indicatorCount - 1);
+  console.log(activeIndicator);
+
+  const indices = indicators.map((index) => (
+    <Fragment key={index}>
+      <svg height="8" width="8">
+        <circle cx="4" cy="4" r="4" />
+      </svg>
+      <style jsx>{`
+        svg {
+          fill: ${index === activeIndicator
+            ? 'var(--accent-color)'
+            : '#cdcdcd'};
+          margin-right: 16px;
+        }
+      `}</style>
+    </Fragment>
+  ));
+
+  return <>{indices}</>;
+}
+
+export default Indicator;

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -1,18 +1,22 @@
-import { ForwardButton, useOrderedPages } from '../OrderedPages';
+import { useOrderedPages } from '../OrderedPages';
 
 const INTEREST_LEVELS = {
-  HIGH: 3,
+  HIGH: 1,
   MIDDLE: 2,
-  LOW: 1,
+  LOW: 3,
 };
 
-function InterestLevel() {
+type Props = {
+  interest: number | null;
+  setInterest: (n: number) => void;
+};
+
+function InterestLevel({ interest, setInterest }: Props) {
   const { pageForward } = useOrderedPages();
 
   const handleInterestSelected = (fn: () => void) => {
     return () => {
       fn();
-      pageForward();
     };
   };
 
@@ -28,24 +32,36 @@ function InterestLevel() {
     setInterest(INTEREST_LEVELS.LOW);
   });
 
-  // フェイク
-  const setInterest = (interest: number) => {
-    return;
-  };
-
   return (
     <>
       <div className="interest-selector">
         <p className="instruction">この募集にどのくらい興味がありますか？</p>
-        <button onClick={onHighSelected}>是非参加したい</button>
+        <button
+          className={`interest-option ${interest === 1 ? 'selected' : ''}`}
+          onClick={onHighSelected}
+        >
+          是非参加したい
+        </button>
         <br />
-        <button onClick={onMiddleSelected}>内容によっては参加したい</button>
+        <button
+          className={`interest-option ${interest === 2 ? 'selected' : ''}`}
+          onClick={onMiddleSelected}
+        >
+          内容によっては参加したい
+        </button>
         <br />
-        <button onClick={onLowSelected}>とりあえず話してみたい</button>
+        <button
+          className={`interest-option ${interest === 3 ? 'selected' : ''}`}
+          onClick={onLowSelected}
+        >
+          とりあえず話してみたい
+        </button>
       </div>
-      {/* <div className="page-controller">
-        <ForwardButton>進む →</ForwardButton>
-      </div> */}
+      <div className="page-controller">
+        <button onClick={() => pageForward()} disabled={interest === null}>
+          進む →
+        </button>
+      </div>
       <style jsx>{`
         .instruction {
           margin-bottom: 16px;
@@ -57,14 +73,21 @@ function InterestLevel() {
         .interest-selector button {
           padding: 16px 32px;
           border-radius: 28px;
+          font-weight: 800;
+          margin-bottom: 12px;
+          background-color: #ffffff;
+          border: 1px solid #25a5ec;
+          color: #25a5ec;
+        }
+        .interest-selector button.selected {
+          padding: 16px 32px;
+          border-radius: 28px;
           border: 0;
           color: #ffffff;
           background-color: #25a5ec;
-          font-weight: 800;
-          margin-bottom: 12px;
         }
-        button:hover {
-          background-color: #36b3f7;
+        .interest-selector button:hover {
+          cursor: pointer;
         }
         .page-controller {
           text-align: center;

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -1,4 +1,4 @@
-import { useOrderedPages } from '../OrderedPages';
+import { ForwardButton } from '../OrderedPages';
 
 const INTEREST_LEVELS = {
   HIGH: 1,
@@ -12,8 +12,6 @@ type Props = {
 };
 
 function InterestLevel({ interest, setInterest }: Props) {
-  const { pageForward } = useOrderedPages();
-
   const handleInterestSelected = (fn: () => void) => {
     return () => {
       fn();
@@ -58,9 +56,7 @@ function InterestLevel({ interest, setInterest }: Props) {
         </button>
       </div>
       <div className="page-controller">
-        <button onClick={() => pageForward()} disabled={interest === null}>
-          進む →
-        </button>
+        <ForwardButton disabled={interest === null}>次へ</ForwardButton>
       </div>
       <style jsx>{`
         .instruction {

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -30,7 +30,7 @@ function InterestLevel() {
   return (
     <>
       <div className="interest-selector">
-        <p className="instruction">この募集にどのくらい興味がありますか？</p>
+        <p className="instruction">現在の興味度を選択してください</p>
         <button
           type="button"
           className={`interest-option ${interest === 1 ? 'selected' : ''}`}
@@ -60,7 +60,9 @@ function InterestLevel() {
       </div>
       <style jsx>{`
         .instruction {
-          margin-bottom: 16px;
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 20px;
         }
         .interest-selector {
           text-align: center;

--- a/components/applicationForm/InterestLevel.tsx
+++ b/components/applicationForm/InterestLevel.tsx
@@ -1,4 +1,5 @@
 import { ForwardButton } from '../OrderedPages';
+import { useApplyFormContext } from '.';
 
 const INTEREST_LEVELS = {
   HIGH: 1,
@@ -6,12 +7,8 @@ const INTEREST_LEVELS = {
   LOW: 3,
 };
 
-type Props = {
-  interest: number | null;
-  setInterest: (n: number) => void;
-};
-
-function InterestLevel({ interest, setInterest }: Props) {
+function InterestLevel() {
+  const { interest, setInterest } = useApplyFormContext();
   const handleInterestSelected = (fn: () => void) => {
     return () => {
       fn();
@@ -35,6 +32,7 @@ function InterestLevel({ interest, setInterest }: Props) {
       <div className="interest-selector">
         <p className="instruction">この募集にどのくらい興味がありますか？</p>
         <button
+          type="button"
           className={`interest-option ${interest === 1 ? 'selected' : ''}`}
           onClick={onHighSelected}
         >
@@ -42,6 +40,7 @@ function InterestLevel({ interest, setInterest }: Props) {
         </button>
         <br />
         <button
+          type="button"
           className={`interest-option ${interest === 2 ? 'selected' : ''}`}
           onClick={onMiddleSelected}
         >
@@ -49,6 +48,7 @@ function InterestLevel({ interest, setInterest }: Props) {
         </button>
         <br />
         <button
+          type="button"
           className={`interest-option ${interest === 3 ? 'selected' : ''}`}
           onClick={onLowSelected}
         >

--- a/components/applicationForm/Message.tsx
+++ b/components/applicationForm/Message.tsx
@@ -1,21 +1,12 @@
 import { ChangeEvent } from 'react';
-import { BackButton, useOrderedPages } from '../OrderedPages';
+import { BackButton } from '../OrderedPages';
+import { useApplyFormContext } from '.';
 
-type Props = {
-  message: string;
-  setMessage: (s: string) => void;
-  onSubmit: () => void;
-};
+function Message() {
+  const { message, setMessage } = useApplyFormContext();
 
-function Message({ message, setMessage, onSubmit }: Props) {
-  const { pageForward } = useOrderedPages();
   const onMessageChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setMessage(e.target.value);
-  };
-
-  const handleSubmit = () => {
-    onSubmit();
-    pageForward();
   };
 
   return (
@@ -34,7 +25,7 @@ function Message({ message, setMessage, onSubmit }: Props) {
       </div>
       <div className="page-controller">
         <BackButton>← 戻る</BackButton>
-        <button onClick={handleSubmit}>送信</button>
+        <button type="submit">送信</button>
       </div>
       <style jsx>{`
         .instruction {

--- a/components/applicationForm/Message.tsx
+++ b/components/applicationForm/Message.tsx
@@ -20,16 +20,18 @@ function Message() {
           name="message"
           onChange={onMessageChange}
           value={message}
-          aria-label="募集主へのメッセージ"
+          aria-label="募集主に伝えたいこと"
         ></textarea>
       </div>
       <div className="page-controller">
-        <BackButton>← 戻る</BackButton>
+        <BackButton>戻る</BackButton>
         <button type="submit">送信</button>
       </div>
       <style jsx>{`
         .instruction {
-          margin-bottom: 4px;
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 20px;
         }
         .message_wrapper {
           text-align: center;
@@ -40,6 +42,8 @@ function Message() {
           padding: 8px;
           max-width: 420px;
           margin-bottom: 24px;
+          border-radius: 4px;
+          border: 1px solid #cdcdcd;
         }
         .page-controller {
           display: flex;
@@ -47,12 +51,12 @@ function Message() {
           justify-content: space-evenly;
         }
         .page-controller button {
-          border-radius: 8px;
+          border-radius: 4px;
           border: 0;
-          padding: 8px 24px;
+          padding: 12px 48px;
           color: #ffffff;
-          background-color: #25a5ec;
-          font-weight: 800;
+          background-color: var(--accent-color);
+          font-weight: 700;
         }
         .page-controller button:hover {
           background-color: #36b3f7;

--- a/components/applicationForm/Message.tsx
+++ b/components/applicationForm/Message.tsx
@@ -1,19 +1,21 @@
 import { ChangeEvent } from 'react';
 import { BackButton, useOrderedPages } from '../OrderedPages';
-function Message() {
+
+type Props = {
+  message: string;
+  setMessage: (s: string) => void;
+  onSubmit: () => void;
+};
+
+function Message({ message, setMessage, onSubmit }: Props) {
   const { pageForward } = useOrderedPages();
   const onMessageChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setMessage(e.target.value);
   };
 
-  const onSubmit = () => {
-    // TODO: API呼ぶ
+  const handleSubmit = () => {
+    onSubmit();
     pageForward();
-  };
-
-  // フェイク
-  const setMessage = (message: string) => {
-    return;
   };
 
   return (
@@ -26,12 +28,13 @@ function Message() {
           id="message"
           name="message"
           onChange={onMessageChange}
+          value={message}
           aria-label="募集主へのメッセージ"
         ></textarea>
       </div>
       <div className="page-controller">
         <BackButton>← 戻る</BackButton>
-        <button onClick={onSubmit}>送信</button>
+        <button onClick={handleSubmit}>送信</button>
       </div>
       <style jsx>{`
         .instruction {

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -11,14 +11,14 @@ function UserClass() {
   return (
     <>
       <div className="user_class_wrapper">
-        <label htmlFor="user_class">自分のクラス</label>
-        <br />
+        <p className="instruction">自分のクラスを入力してください</p>
         <input
           id="user_class"
           type="text"
           value={userClass}
           name="user_class"
           onChange={onChangeUserClass}
+          aria-label="自分のクラス"
         />
         <p className="note">
           募集主はあなたの所属するクラスを知ることができます
@@ -26,19 +26,26 @@ function UserClass() {
       </div>
       <div className="page-controller">
         <BackButton>戻る</BackButton>
-        <ForwardButton disabled={userClass.length === 0}>進む</ForwardButton>
+        <ForwardButton disabled={userClass.length === 0}>次へ</ForwardButton>
       </div>
       <style jsx>{`
         .user_class_wrapper {
           text-align: center;
           margin-bottom: 24px;
         }
+        .instruction {
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-bottom: 48px;
+        }
         input {
           font-size: 1.1rem;
-          width: 120px;
-          padding: 4px 8px;
+          width: 60%;
+          padding: 12px 16px;
           margin-top: 4px;
-          margin-bottom: 24px;
+          margin-bottom: 18px;
+          border-radius: 4px;
+          border: 1px solid #cdcdcd;
         }
         .note {
           font-size: 0.8rem;

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -1,12 +1,9 @@
 import type { ChangeEvent } from 'react';
 import { ForwardButton, BackButton } from '../OrderedPages';
+import { useApplyFormContext } from '.';
 
-type Props = {
-  userClass: string;
-  setUserClass: (s: string) => void;
-};
-
-function UserClass({ userClass, setUserClass }: Props) {
+function UserClass() {
+  const { userClass, setUserClass } = useApplyFormContext();
   const onChangeUserClass = (e: ChangeEvent<HTMLInputElement>) => {
     setUserClass(e.target.value);
   };

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import { ForwardButton, BackButton, useOrderedPages } from '../OrderedPages';
+import { ForwardButton, BackButton } from '../OrderedPages';
 
 type Props = {
   userClass: string;
@@ -7,7 +7,6 @@ type Props = {
 };
 
 function UserClass({ userClass, setUserClass }: Props) {
-  const { pageForward } = useOrderedPages();
   const onChangeUserClass = (e: ChangeEvent<HTMLInputElement>) => {
     setUserClass(e.target.value);
   };
@@ -29,10 +28,8 @@ function UserClass({ userClass, setUserClass }: Props) {
         </p>
       </div>
       <div className="page-controller">
-        <BackButton>← 戻る</BackButton>
-        <button onClick={() => pageForward()} disabled={userClass.length === 0}>
-          進む →
-        </button>
+        <BackButton>戻る</BackButton>
+        <ForwardButton disabled={userClass.length === 0}>進む</ForwardButton>
       </div>
       <style jsx>{`
         .user_class_wrapper {

--- a/components/applicationForm/UserClass.tsx
+++ b/components/applicationForm/UserClass.tsx
@@ -1,14 +1,15 @@
 import type { ChangeEvent } from 'react';
-import { ForwardButton, BackButton } from '../OrderedPages';
+import { ForwardButton, BackButton, useOrderedPages } from '../OrderedPages';
 
-function UserClass() {
+type Props = {
+  userClass: string;
+  setUserClass: (s: string) => void;
+};
+
+function UserClass({ userClass, setUserClass }: Props) {
+  const { pageForward } = useOrderedPages();
   const onChangeUserClass = (e: ChangeEvent<HTMLInputElement>) => {
     setUserClass(e.target.value);
-  };
-
-  // フェイク
-  const setUserClass = (userClass: string) => {
-    return;
   };
 
   return (
@@ -19,6 +20,7 @@ function UserClass() {
         <input
           id="user_class"
           type="text"
+          value={userClass}
           name="user_class"
           onChange={onChangeUserClass}
         />
@@ -28,7 +30,9 @@ function UserClass() {
       </div>
       <div className="page-controller">
         <BackButton>← 戻る</BackButton>
-        <ForwardButton>進む →</ForwardButton>
+        <button onClick={() => pageForward()} disabled={userClass.length === 0}>
+          進む →
+        </button>
       </div>
       <style jsx>{`
         .user_class_wrapper {

--- a/components/applicationForm/index.tsx
+++ b/components/applicationForm/index.tsx
@@ -1,10 +1,29 @@
+import { useState } from 'react';
+import { useApplyOffer } from '../../hooks/requests/offers';
 import { OrderedPages, Page, Indicator } from '../OrderedPages';
 import Completed from './Completed';
 import InterestLevel from './InterestLevel';
 import Message from './Message';
 import UserClass from './UserClass';
 
-function ApplicationForm() {
+type Props = {
+  offerId: number;
+};
+
+function ApplicationForm({ offerId }: Props) {
+  const { mutate } = useApplyOffer();
+  const [interest, setInterest] = useState<number | null>(null);
+  const [userClass, setUserClass] = useState('');
+  const [message, setMessage] = useState('');
+
+  const onSubmit = () => {
+    mutate({
+      offer_id: offerId,
+      interest: interest || 1,
+      user_class: userClass,
+      message,
+    });
+  };
   return (
     <div role="form" aria-label="募集主に連絡をとる">
       <OrderedPages>
@@ -12,19 +31,23 @@ function ApplicationForm() {
           <div className="indicator">
             <Indicator />
           </div>
-          <InterestLevel />
+          <InterestLevel interest={interest} setInterest={setInterest} />
         </Page>
         <Page>
           <div className="indicator">
             <Indicator />
           </div>
-          <UserClass />
+          <UserClass userClass={userClass} setUserClass={setUserClass} />
         </Page>
         <Page>
           <div className="indicator">
             <Indicator />
           </div>
-          <Message />
+          <Message
+            message={message}
+            setMessage={setMessage}
+            onSubmit={onSubmit}
+          />
         </Page>
         <Page>
           <Completed />

--- a/components/applicationForm/index.tsx
+++ b/components/applicationForm/index.tsx
@@ -36,7 +36,7 @@ type PagedApplyFormProps = {
 
 function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
   const { pageForward } = useOrderedPages();
-  const { mutate } = useApplyOffer();
+  const { mutate, isLoading, isError } = useApplyOffer();
   const [interest, setInterest] = useState<number | null>(null);
   const [userClass, setUserClass] = useState('');
   const [message, setMessage] = useState('');
@@ -58,6 +58,8 @@ function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
     );
   };
 
+  console.log(isLoading);
+
   return (
     <ApplyFormContext.Provider
       value={{
@@ -70,6 +72,23 @@ function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
       }}
     >
       <form onSubmit={onSubmit}>{children}</form>
+      {isLoading && <p className="message load">データを送信中...</p>}
+      {isError && (
+        <p className="message error">
+          データの送信に失敗しました。しばらくしてから再度送信してください。
+        </p>
+      )}
+      <style jsx>{`
+        .message {
+          margin-top: 12px;
+          text-align: center;
+        }
+        .message.error {
+          margin-top: 12px;
+          text-align: center;
+          color: #ff0000;
+        }
+      `}</style>
     </ApplyFormContext.Provider>
   );
 }

--- a/components/applicationForm/index.tsx
+++ b/components/applicationForm/index.tsx
@@ -2,12 +2,13 @@ import { createContext, useContext, useState } from 'react';
 import type { Dispatch, MouseEvent, ReactNode, SetStateAction } from 'react';
 import { useApplyOffer } from '../../hooks/requests/offers';
 import {
+  ForwardButton,
   OrderedPages,
   Page,
-  Indicator,
   useOrderedPages,
 } from '../OrderedPages';
 import Completed from './Completed';
+import Indicator from './Indicator';
 import InterestLevel from './InterestLevel';
 import Message from './Message';
 import UserClass from './UserClass';
@@ -43,22 +44,21 @@ function PagedApplyForm({ offerId, children }: PagedApplyFormProps) {
 
   const onSubmit = (e: MouseEvent<HTMLFormElement>) => {
     e.preventDefault();
-    mutate(
-      {
-        offer_id: offerId,
-        interest: interest || 1,
-        user_class: userClass,
-        message,
-      },
-      {
-        onSuccess() {
-          pageForward();
-        },
-      }
-    );
+    // mutate(
+    //   {
+    //     offer_id: offerId,
+    //     interest: interest || 1,
+    //     user_class: userClass,
+    //     message,
+    //   },
+    //   {
+    //     onSuccess() {
+    //       pageForward();
+    //     },
+    //   }
+    // );
+    pageForward();
   };
-
-  console.log(isLoading);
 
   return (
     <ApplyFormContext.Provider
@@ -100,29 +100,29 @@ type ApplyFormProps = {
 function ApplyForm({ offerId }: ApplyFormProps) {
   return (
     <OrderedPages>
+      <div className="indicator">
+        <Indicator />
+      </div>
       <PagedApplyForm offerId={offerId}>
         <Page>
-          <div className="indicator">
-            <Indicator />
-          </div>
           <InterestLevel />
         </Page>
         <Page>
-          <div className="indicator">
-            <Indicator />
-          </div>
           <UserClass />
         </Page>
         <Page>
-          <div className="indicator">
-            <Indicator />
-          </div>
           <Message />
         </Page>
         <Page>
           <Completed />
         </Page>
       </PagedApplyForm>
+      <style jsx>{`
+        .indicator {
+          text-align: center;
+          margin-bottom: 12px;
+        }
+      `}</style>
     </OrderedPages>
   );
 }

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from 'next/link';
+import { useLoginUser } from '../../hooks/requests/auth';
 import NavLink from '../NavLink';
 
 export default function Header() {
+  const { data } = useLoginUser();
+
   return (
     <>
       <header>
@@ -47,17 +50,19 @@ export default function Header() {
             </ul>
           </nav>
         </div>
-        <div>
-          <Link href="/user/2180372">
-            <a aria-label="プロフィール画面へ">
-              <img
-                alt="ユーザーアイコン"
-                className="user-icon"
-                src="https://placeimg.com/200/200/animals"
-              ></img>
-            </a>
-          </Link>
-        </div>
+        {data ? (
+          <div>
+            <Link href={`/user/${data.user.student_number}`}>
+              <a aria-label="プロフィール画面へ">
+                <div className="user-icon"></div>
+              </a>
+            </Link>
+          </div>
+        ) : (
+          <div>
+            <Link href="/login">ログイン</Link>
+          </div>
+        )}
       </header>
       <style jsx>{`
         header {
@@ -82,8 +87,10 @@ export default function Header() {
         }
         .user-icon {
           width: 50px;
+          height: 50px;
           clip-path: circle(50%);
           margin-right: 40px;
+          background-color: gray;
         }
         nav {
           display: inline-block;

--- a/hooks/requests/auth.ts
+++ b/hooks/requests/auth.ts
@@ -1,0 +1,20 @@
+import { useQuery } from 'react-query';
+import { jsonClient } from '../../utils/httpClient';
+import type { User } from './profile';
+
+type GetLoginUserResponse = {
+  user: User;
+};
+
+function useLoginUser() {
+  return useQuery<GetLoginUserResponse, Error>(
+    ['auth'],
+    () => jsonClient('/user/whoami'),
+    {
+      staleTime: Infinity,
+      cacheTime: Infinity,
+    }
+  );
+}
+
+export { useLoginUser };

--- a/hooks/requests/auth.ts
+++ b/hooks/requests/auth.ts
@@ -1,4 +1,5 @@
 import { useQuery } from 'react-query';
+import { API_HOST } from '../../utils/configs';
 import { jsonClient } from '../../utils/httpClient';
 import type { User } from './profile';
 
@@ -9,7 +10,7 @@ type GetLoginUserResponse = {
 function useLoginUser() {
   return useQuery<GetLoginUserResponse, Error>(
     ['auth'],
-    () => jsonClient('/user/whoami'),
+    () => jsonClient(API_HOST + '/user/whoami'),
     {
       staleTime: Infinity,
       cacheTime: Infinity,

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -4,6 +4,7 @@ import {
   useQueryClient,
   useMutation,
 } from 'react-query';
+import { API_HOST } from '../../utils/configs';
 import { jsonClient } from '../../utils/httpClient';
 import type { Tag } from './tags';
 import type { PaginatedResponse } from './typeUtils';
@@ -71,7 +72,7 @@ function useInfiniteOffers(
     ['offers', offer_tag_ids],
     ({ pageParam }) => {
       pageParam || (pageParam = page);
-      return jsonClient('/offer/list', {
+      return jsonClient(API_HOST + '/offer/list', {
         params: { offer_tag_ids, page: pageParam },
       });
     },
@@ -100,7 +101,7 @@ function useOffer({ offer_id }: GetOfferRequest, enabled = true) {
   return useQuery<GetOfferResponse>(
     ['offer', offer_id],
     () =>
-      jsonClient('/offer/single', {
+      jsonClient(API_HOST + '/offer/single', {
         params: { offer_id: offer_id.toString() },
       }),
     {
@@ -113,7 +114,7 @@ function useAddOffer() {
   const queryClient = useQueryClient();
   return useMutation<AddOfferResponse, Error, AddOfferRequest>(
     (newOffer) => {
-      return jsonClient('/mock/offer/post', {
+      return jsonClient(API_HOST + '/offer/post', {
         method: 'POST',
         body: { ...newOffer },
       });
@@ -131,7 +132,7 @@ function useEditOffer() {
   const queryClient = useQueryClient();
   return useMutation<EditOfferResponse, Error, EditOfferRequest>(
     (newOffer) => {
-      return jsonClient('/mock/offer/edit', {
+      return jsonClient(API_HOST + '/offer/edit', {
         method: 'POST',
         body: { ...newOffer },
       });
@@ -154,7 +155,7 @@ function useUserOffers(
   return useQuery<GetUserOffersResponse>(
     ['offers', 'user', student_number],
     () =>
-      jsonClient('/user/offer-list', {
+      jsonClient(API_HOST + '/user/offer-list', {
         params: {
           student_number,
         },

--- a/hooks/requests/offers.ts
+++ b/hooks/requests/offers.ts
@@ -36,6 +36,14 @@ type GetOfferResponse = {
   offer: Offer;
 };
 
+type ApplyRequest = {
+  offer_id: number;
+  interest: number;
+  user_class: string;
+  message: string;
+};
+type ApplyResponse = void;
+
 type AddOfferRequest = {
   title: string;
   target: string;
@@ -110,13 +118,32 @@ function useOffer({ offer_id }: GetOfferRequest, enabled = true) {
   );
 }
 
+function useApplyOffer() {
+  return useMutation<ApplyResponse, Error, ApplyRequest>((options) => {
+    return jsonClient(API_HOST + '/offer/apply', {
+      method: 'POST',
+      body: { ...options },
+    });
+  });
+}
+
 function useAddOffer() {
   const queryClient = useQueryClient();
   return useMutation<AddOfferResponse, Error, AddOfferRequest>(
     (newOffer) => {
+      const m = (new Date(newOffer.end_date).getMonth() + 1).toString();
+      const d = new Date(newOffer.end_date).getDate().toString();
+
+      const ymd =
+        new Date(newOffer.end_date).getFullYear() +
+        '-' +
+        (m.length === 1 ? '0' + m : m) +
+        '-' +
+        (d.length === 1 ? '0' + d : d);
+
       return jsonClient(API_HOST + '/offer/post', {
         method: 'POST',
-        body: { ...newOffer },
+        body: { ...newOffer, picture: null, end_date: ymd },
       });
     },
     {
@@ -173,6 +200,7 @@ function useUserOffers(
 
 export type { Offer };
 export {
+  useApplyOffer,
   useAddOffer,
   useEditOffer,
   useInfiniteOffers,

--- a/hooks/requests/profile.ts
+++ b/hooks/requests/profile.ts
@@ -1,4 +1,4 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQuery } from 'react-query';
 import { jsonClient } from '../../utils/httpClient';
 
 type User = {
@@ -7,6 +7,13 @@ type User = {
   email?: string;
   link?: string;
   self_introduction: string;
+};
+
+type GetUserRequest = {
+  student_number: string;
+};
+type GetUserResponse = {
+  user: User;
 };
 
 type EditUserRequest = {
@@ -24,6 +31,16 @@ type EditEmailRequest = {
 type EditEmailResponse = {
   user: User;
 };
+
+function useUser({ student_number }: GetUserRequest, enabled = true) {
+  return useQuery<GetUserResponse, Error>(
+    ['user', student_number],
+    () => jsonClient('/user/single'),
+    {
+      enabled,
+    }
+  );
+}
 
 function useEditUser() {
   return useMutation<EditUserResponse, Error, EditUserRequest>(
@@ -57,4 +74,4 @@ function useEditEmail() {
   );
 }
 export type { User };
-export { useEditUser, useEditEmail };
+export { useUser, useEditUser, useEditEmail };

--- a/hooks/requests/profile.ts
+++ b/hooks/requests/profile.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from 'react-query';
+import { API_HOST } from '../../utils/configs';
 import { jsonClient } from '../../utils/httpClient';
 
 type User = {
@@ -35,7 +36,10 @@ type EditEmailResponse = {
 function useUser({ student_number }: GetUserRequest, enabled = true) {
   return useQuery<GetUserResponse, Error>(
     ['user', student_number],
-    () => jsonClient('/user/single'),
+    () =>
+      jsonClient(API_HOST + '/user/single', {
+        params: { student_number },
+      }),
     {
       enabled,
     }
@@ -45,7 +49,7 @@ function useUser({ student_number }: GetUserRequest, enabled = true) {
 function useEditUser() {
   return useMutation<EditUserResponse, Error, EditUserRequest>(
     (newUser) => {
-      return jsonClient('/mock/user/edit', {
+      return jsonClient(API_HOST + '/user/edit', {
         method: 'POST',
         body: { ...newUser },
       });
@@ -61,7 +65,7 @@ function useEditUser() {
 function useEditEmail() {
   return useMutation<EditEmailResponse, Error, EditEmailRequest>(
     (newEmail) => {
-      return jsonClient('/mock/user/edit-email', {
+      return jsonClient(API_HOST + '/user/edit-email', {
         method: 'POST',
         body: { ...newEmail },
       });

--- a/hooks/requests/tags.ts
+++ b/hooks/requests/tags.ts
@@ -1,4 +1,5 @@
 import { useQuery } from 'react-query';
+import { API_HOST } from '../../utils/configs';
 import { jsonClient } from '../../utils/httpClient';
 
 type Tag = {
@@ -21,7 +22,7 @@ function useTags({ tag_genre_id }: GetTagsRequest) {
   return useQuery<GetTagsResponse, Error>(
     ['tags', { tag_genre_id }],
     () =>
-      jsonClient('/tag-list', {
+      jsonClient(API_HOST + '/tag-list', {
         params: {
           tag_genre_id,
         },

--- a/mocks/handlers/auth.ts
+++ b/mocks/handlers/auth.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 
 export const authHandlers = [
-  rest.get('/login', (req, res, ctx) => {
+  rest.get('/api/login', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -9,7 +9,7 @@ export const authHandlers = [
       })
     );
   }),
-  rest.get('/logout', (req, res, ctx) => {
+  rest.get('/api/logout', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -17,7 +17,7 @@ export const authHandlers = [
       })
     );
   }),
-  rest.get('/user/whoami', (req, res, ctx) => {
+  rest.get('/api/user/whoami', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/mocks/handlers/constants.ts
+++ b/mocks/handlers/constants.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 
 export const constantsHandlers = [
-  rest.get('/tag-list', (req, res, ctx) => {
+  rest.get('/api/tag-list', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/mocks/handlers/offers.ts
+++ b/mocks/handlers/offers.ts
@@ -2,7 +2,7 @@ import { rest } from 'msw';
 import { getPaginationInfo } from '../utils';
 
 export const offersHandlers = [
-  rest.get('/offer/list', (req, res, ctx) => {
+  rest.get('/api/offer/list', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -11,7 +11,7 @@ export const offersHandlers = [
       })
     );
   }),
-  rest.get('/user/offer-list', (req, res, ctx) => {
+  rest.get('/api/user/offer-list', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -20,7 +20,7 @@ export const offersHandlers = [
       })
     );
   }),
-  rest.get('/offer/single', (req, res, ctx) => {
+  rest.get('/api/offer/single', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -28,7 +28,7 @@ export const offersHandlers = [
       })
     );
   }),
-  rest.post('/mock/offer/post', (req, res, ctx) => {
+  rest.post('/api/offer/post', (req, res, ctx) => {
     return res(
       ctx.status(201),
       ctx.json({
@@ -36,10 +36,10 @@ export const offersHandlers = [
       })
     );
   }),
-  rest.post('offer/delete', (req, res, ctx) => {
+  rest.post('/api/offer/delete', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
   }),
-  rest.post('/mock/offer/edit', (req, res, ctx) => {
+  rest.post('/api/offer/edit', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -47,7 +47,7 @@ export const offersHandlers = [
       })
     );
   }),
-  rest.post('/offer/apply', (req, res, ctx) => {
+  rest.post('/api/offer/apply', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
   }),
 ];

--- a/mocks/handlers/profile.ts
+++ b/mocks/handlers/profile.ts
@@ -2,6 +2,14 @@ import { rest } from 'msw';
 import { user } from './auth';
 
 export const profileHandlers = [
+  rest.get('/user/single', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        user,
+      })
+    );
+  }),
   rest.get('/user/regist', (req, res, ctx) => {
     return res(
       ctx.status(201),

--- a/mocks/handlers/profile.ts
+++ b/mocks/handlers/profile.ts
@@ -2,7 +2,7 @@ import { rest } from 'msw';
 import { user } from './auth';
 
 export const profileHandlers = [
-  rest.get('/user/single', (req, res, ctx) => {
+  rest.get('/api/user/single', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -10,7 +10,7 @@ export const profileHandlers = [
       })
     );
   }),
-  rest.get('/user/regist', (req, res, ctx) => {
+  rest.get('api/user/regist', (req, res, ctx) => {
     return res(
       ctx.status(201),
       ctx.json({
@@ -18,7 +18,7 @@ export const profileHandlers = [
       })
     );
   }),
-  rest.post('/mock/user/edit', (req, res, ctx) => {
+  rest.post('/api/user/edit', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -26,7 +26,7 @@ export const profileHandlers = [
       })
     );
   }),
-  rest.get('/user/regist-email', (req, res, ctx) => {
+  rest.get('/api/user/regist-email', (req, res, ctx) => {
     return res(
       ctx.status(201),
       ctx.json({
@@ -34,7 +34,7 @@ export const profileHandlers = [
       })
     );
   }),
-  rest.post('/mock/user/edit-email', (req, res, ctx) => {
+  rest.post('/api/user/edit-email', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/mocks/handlers/promotions.ts
+++ b/mocks/handlers/promotions.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 
 export const promotionsHandlers = [
-  rest.get('/promotion/list', (req, res, ctx) => {
+  rest.get('/api/promotion/list', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -9,7 +9,7 @@ export const promotionsHandlers = [
       })
     );
   }),
-  rest.get('/user/promotion-list', (req, res, ctx) => {
+  rest.get('/api/user/promotion-list', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -17,7 +17,7 @@ export const promotionsHandlers = [
       })
     );
   }),
-  rest.get('/promotion/single', (req, res, ctx) => {
+  rest.get('/api/promotion/single', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -25,7 +25,7 @@ export const promotionsHandlers = [
       })
     );
   }),
-  rest.post('promotion/post', (req, res, ctx) => {
+  rest.post('/api/promotion/post', (req, res, ctx) => {
     return res(
       ctx.status(201),
       ctx.json({
@@ -33,10 +33,10 @@ export const promotionsHandlers = [
       })
     );
   }),
-  rest.post('offer/delete', (req, res, ctx) => {
+  rest.post('/api/offer/delete', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
   }),
-  rest.post('promotion/edit', (req, res, ctx) => {
+  rest.post('/api/promotion/edit', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/mocks/handlers/support.ts
+++ b/mocks/handlers/support.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 
 export const supportHandlers = [
-  rest.post('/contact', (req, res, ctx) => {
+  rest.post('/api/contact', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
   }),
 ];

--- a/mocks/handlers/works.ts
+++ b/mocks/handlers/works.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 
 export const worksHandlers = [
-  rest.get('/work/list', (req, res, ctx) => {
+  rest.get('/api/work/list', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -9,7 +9,7 @@ export const worksHandlers = [
       })
     );
   }),
-  rest.get('/user/work-list', (req, res, ctx) => {
+  rest.get('/api/user/work-list', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -17,7 +17,7 @@ export const worksHandlers = [
       })
     );
   }),
-  rest.get('/work/single', (req, res, ctx) => {
+  rest.get('/api/work/single', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -25,7 +25,7 @@ export const worksHandlers = [
       })
     );
   }),
-  rest.post('work/post', (req, res, ctx) => {
+  rest.post('/api/work/post', (req, res, ctx) => {
     return res(
       ctx.status(201),
       ctx.json({
@@ -33,10 +33,10 @@ export const worksHandlers = [
       })
     );
   }),
-  rest.post('work/delete', (req, res, ctx) => {
+  rest.post('/api/work/delete', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
   }),
-  rest.post('work/edit', (req, res, ctx) => {
+  rest.post('/api/work/edit', (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({

--- a/pages/board/offers/[offerId].tsx
+++ b/pages/board/offers/[offerId].tsx
@@ -51,6 +51,29 @@ function OfferDetailPage() {
       {error && <p role="alert">エラーが発生しました。詳細: error.message</p>}
       {offer && (
         <div className="offer">
+          <div className="top-info">
+            <div className="user-info">
+              <div className="user-icon"></div>
+              <div>
+                <div>
+                  <span className="user-class">{offer.user_class || ''}</span>
+                  <span className="student-number">{offer.student_number}</span>
+                </div>
+                <span className="user-name">{offer.user_name}</span>
+              </div>
+            </div>
+            <p>{offer.end_date}に掲載終了</p>
+          </div>
+          {offer.picture ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={offer.picture}
+              alt="投稿主がアップロードした画像"
+              className="offer-image"
+            />
+          ) : (
+            <div className="offer-image">{offer.tags[0].name}</div>
+          )}
           <h1>{offer.title}</h1>
           <div className="tags">
             {offer.tags.map((tag) => (
@@ -59,30 +82,36 @@ function OfferDetailPage() {
               </span>
             ))}
           </div>
-          <div className="offerer">
-            募集主の情報:
-            <br />
-            {offer.user_name} {offer.user_class} {offer.student_number}
+          <div className="info-grid">
+            <div className="offer-info">
+              {offer.note && <p className="note">{offer.note}</p>}
+              <div className="extra-info">
+                <div className="circle" />
+                投稿日 <br />
+                {offer.post_date}
+              </div>
+              <div className="extra-info">
+                <div className="circle" />
+                参考リンク
+                <br />
+                {offer.link ? <a href={offer.link}>{offer.link}</a> : 'なし'}
+              </div>
+              <div className="extra-info">
+                <div className="circle" />
+                募集対象者 <br />
+                {offer.target || '明記なし'}
+              </div>
+              <div className="extra-info">
+                <div className="circle" />
+                役職と人数 <br />
+                {offer.job || '明記なし'}
+              </div>
+            </div>
+            <div className="application-info">
+              <button onClick={() => setShowModal(true)}>興味がある</button>
+            </div>
           </div>
-          <p>募集対象者: {offer.target || '明記なし'}</p>
-          <p>役職と人数: {offer.job || '明記なし'}</p>
-          <p>備考: {offer.note || ''}</p>
-          {offer.picture && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={offer.picture}
-              alt="投稿主がアップロードした画像"
-              width="300"
-              height="200"
-            />
-          )}
-          <p>
-            参考リンク:{' '}
-            {offer.link ? <a href={offer.link}>{offer.link}</a> : 'なし'}
-          </p>
-          <p>投稿日: {offer.post_date}</p>
-          <p>掲載終了日: {offer.end_date}</p>
-          <button onClick={() => setShowModal(true)}>興味がある</button>
+
           <Modal
             className={`modal ${modalClassName}`}
             isOpen={showModal}
@@ -97,23 +126,89 @@ function OfferDetailPage() {
       )}
       <style jsx>
         {`
-          .tag {
-            background-color: lightgray;
-            margin: 0 4px;
+          .offer {
+            width: 70%;
+            margin: auto;
           }
-          .offerer {
-            margin-bottom: 8px;
+          .top-info {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+          }
+          .offer-image {
+            width: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background-color: var(--accent-color);
+            color: #ffffff;
+            font-weight: 700;
+            aspect-ratio: 16/9;
+          }
+          .tags {
+            display: flex;
+            flex-wrap: wrap;
+            margin-bottom: 40px;
+          }
+          .tag {
+            margin: 4px;
+            color: var(--accent-color);
+            font-size: 0.9rem;
+            padding: 4px 8px;
+            border: var(--accent-color) solid 1px;
+            border-radius: 16px;
+            white-space: nowrap;
+          }
+          .info-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+          }
+          .offer-info {
+            grid-column: 1 / 3;
+            padding-right: 12px;
+          }
+          .application-info {
+            grid-column: 3 / 3;
+            position: relative;
+          }
+          .application-info button {
+            background-color: var(--accent-color);
+            color: #ffffff;
+            border: 0;
+            margin-left: 10%;
+            width: 90%;
+            padding: 8px;
+            border-radius: 32px;
+          }
+          .note {
+            margin-bottom: 24px;
+            white-space: pre-wrap;
+          }
+          .extra-info {
+            margin: 16px 0;
+          }
+          .circle {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background-color: var(--accent-color);
+            margin-right: 4px;
           }
           .modal-header {
             display: flex;
             flex-direction: row-reverse;
           }
-          button {
-            margin-bottom: 8px;
-            position: absolute;
+          .user-info {
+            display: flex;
+            align-items: flex-end;
           }
-          p {
-            margin-bottom: 8px;
+          .user-icon {
+            width: 45px;
+            height: 45px;
+            margin-right: 6px;
+            border-radius: 59%;
+            background-color: #707070;
           }
         `}
       </style>

--- a/pages/board/offers/[offerId].tsx
+++ b/pages/board/offers/[offerId].tsx
@@ -91,7 +91,7 @@ function OfferDetailPage() {
             <div className="modal-header">
               <button onClick={() => setShowModal(false)}>X</button>
             </div>
-            <ApplicationForm />
+            <ApplicationForm offerId={offer.id} />
           </Modal>
         </div>
       )}

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -68,7 +68,10 @@ function AllOffersPage() {
       <div>
         <Link href="/offer/post">投稿する</Link>
       </div>
-      <button onClick={toggleFilter}>フィルター</button>
+      <button className="filter-toggle" onClick={toggleFilter}>
+        フィルター
+        <img className="dropdown-icon" src="/dropdown.svg" />
+      </button>
       <PopupMenu
         isOpen={showFilter}
         onRequestClose={() => setShowFilter(false)}
@@ -132,6 +135,17 @@ function AllOffersPage() {
             flex-wrap: wrap;
             align-items: start;
             margin: 10px;
+          }
+          .filter-toggle {
+            padding: 12px 18px;
+            background-color: #ffffff;
+            border-radius: 22.5px;
+            border: 1px solid #9e9e9e;
+            font-weight: 700;
+            color: var(--black-900);
+          }
+          .dropdown-icon {
+            margin-left: 18px;
           }
           .filter-option {
             white-space: nowrap;

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -104,8 +104,9 @@ function AllOffersPage() {
                     />
                   </Fragment>
                 ))}
-              <br />
-              <button>この条件で検索</button>
+              <div className="search-button-ccontainer">
+                <button className="basic-button search">この条件で検索</button>
+              </div>
             </form>
           )}
         </TagProvider>
@@ -123,8 +124,9 @@ function AllOffersPage() {
         </div>
       )}
       {hasNextPage && (
-        <div>
+        <div className="load-button-container">
           <button
+            className="basic-button load-more"
             onClick={() => fetchNextPage()}
             disabled={!hasNextPage || isFetchingNextPage}
           >
@@ -135,6 +137,11 @@ function AllOffersPage() {
       {isFetching && <p>ロード中...</p>}
       <style jsx>
         {`
+          .search-button-ccontainer {
+            display: flex;
+            justify-content: flex-end;
+            margin-right: 20px;
+          }
           .offers-container {
             display: flex;
             flex-wrap: wrap;
@@ -174,6 +181,18 @@ function AllOffersPage() {
           .filter-option {
             white-space: nowrap;
             margin: 8px;
+          }
+          .load-button-container {
+            display: flex;
+            justify-content: center;
+          }
+          .basic-button {
+            color: #ffffff;
+            background-color: var(--accent-color);
+            border: 0;
+            padding: 12px 18px;
+            border-radius: 5px;
+            font-weight: 700;
           }
         `}
       </style>

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -45,7 +45,8 @@ function AllOffersPage() {
       margin-left: 4px;
       background-color: white;
       border-radius: 8px;
-      border: solid grey 1px;
+      padding: 16px;
+      box-shadow: 4px 8px 24px rgba(155, 155, 155, 0.7);
     }
   `;
 
@@ -85,25 +86,29 @@ function AllOffersPage() {
         <TagProvider tag_genre_id={1}>
           {({ data, isLoading, error }) => (
             <form className="filter-popup" onSubmit={onSubmit}>
+              <h2 className="filter-title">絞り込み</h2>
               {isLoading && <span>ロード中...</span>}
               {error && (
                 <span>エラーが発生しました。詳細: {error.message}</span>
               )}
-              {data &&
-                data.tags.map((tag, i) => (
-                  <Fragment key={tag.id}>
-                    <label htmlFor={`tag${i}`} className="filter-option">
-                      {tag.name}
-                    </label>
-                    <input
-                      id={`tag${i}`}
-                      type="checkbox"
-                      value={tag.id}
-                      defaultChecked={offer_tag_ids.includes(tag.id)}
-                      {...register(`offer_tag_ids.${i}`)}
-                    />
-                  </Fragment>
-                ))}
+              {data && (
+                <div className="filter-option-wrapper">
+                  {data.tags.map((tag, i) => (
+                    <div key={tag.id} className="filter-option">
+                      <input
+                        id={`tag${i}`}
+                        type="checkbox"
+                        value={tag.id}
+                        defaultChecked={offer_tag_ids.includes(tag.id)}
+                        {...register(`offer_tag_ids.${i}`)}
+                      />
+                      <label htmlFor={`tag${i}`} className="filter-label">
+                        {tag.name}
+                      </label>
+                    </div>
+                  ))}
+                </div>
+              )}
               <div className="search-button-ccontainer">
                 <button className="basic-button search">この条件で検索</button>
               </div>
@@ -178,9 +183,21 @@ function AllOffersPage() {
           .dropdown-icon {
             margin-left: 18px;
           }
+          .filter-title {
+            margin-bottom: 8px;
+          }
+          .filter-option-wrapper {
+            padding-block: 12px;
+            border-block: 1px solid #cdcdcd;
+            margin-bottom: 12px;
+          }
           .filter-option {
+            display: inline;
             white-space: nowrap;
-            margin: 8px;
+          }
+          .filter-label {
+            margin-right: 8px;
+            line-height: 2;
           }
           .load-button-container {
             display: flex;

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -139,6 +139,7 @@ function AllOffersPage() {
             display: flex;
             flex-wrap: wrap;
             align-items: start;
+            justify-content: center;
             margin: 10px;
           }
           .top {

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -65,7 +65,6 @@ function AllOffersPage() {
 
   return (
     <div>
-      <h1>募集一覧</h1>
       <div className="top">
         <button className="filter-toggle" onClick={toggleFilter}>
           フィルター
@@ -158,6 +157,7 @@ function AllOffersPage() {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            margin-top: 24px;
             padding-inline: 32px;
           }
           .new-post {

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -65,13 +65,18 @@ function AllOffersPage() {
   return (
     <div>
       <h1>募集一覧</h1>
-      <div>
-        <Link href="/offer/post">投稿する</Link>
+      <div className="top">
+        <button className="filter-toggle" onClick={toggleFilter}>
+          フィルター
+          <img className="dropdown-icon" src="/dropdown.svg" />
+        </button>
+        <Link href="/offer/post">
+          <a className="new-post">
+            <img className="plus-icon" src="/plus.svg" />
+            投稿する
+          </a>
+        </Link>
       </div>
-      <button className="filter-toggle" onClick={toggleFilter}>
-        フィルター
-        <img className="dropdown-icon" src="/dropdown.svg" />
-      </button>
       <PopupMenu
         isOpen={showFilter}
         onRequestClose={() => setShowFilter(false)}
@@ -136,6 +141,23 @@ function AllOffersPage() {
             align-items: start;
             margin: 10px;
           }
+          .top {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding-inline: 32px;
+          }
+          .new-post {
+            background-color: var(--accent-color);
+            padding: 12px 18px 12px 12px;
+            border-radius: 5px;
+            color: #ffffff;
+            font-weight: 700;
+          }
+          .plus-icon {
+            margin-right: 18px;
+            vertical-align: middle;
+          }
           .filter-toggle {
             padding: 12px 18px;
             background-color: #ffffff;
@@ -143,6 +165,7 @@ function AllOffersPage() {
             border: 1px solid #9e9e9e;
             font-weight: 700;
             color: var(--black-900);
+            vertical-align: middle;
           }
           .dropdown-icon {
             margin-left: 18px;

--- a/pages/board/offers/index.tsx
+++ b/pages/board/offers/index.tsx
@@ -166,6 +166,7 @@ function AllOffersPage() {
             border-radius: 5px;
             color: #ffffff;
             font-weight: 700;
+            text-decoration: none;
           }
           .plus-icon {
             margin-right: 18px;

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -7,7 +7,8 @@ import Header from '../../components/layouts/Header';
 import Layout from '../../components/layouts/Layout';
 import OfferOverview from '../../components/OfferOverview';
 import UserOfferProvider from '../../components/UserOfferProvider';
-import { user } from '../../mocks/handlers/auth';
+import { useLoginUser } from '../../hooks/requests/auth';
+import { useUser } from '../../hooks/requests/profile';
 
 function UserProfilePage() {
   // https://github.com/reactjs/react-tabs#resetidcounter-void
@@ -60,59 +61,67 @@ function UserProfilePage() {
   const router = useRouter();
   const userId = router.query.userId as string;
 
-  // TODO: userログインユーザーと取得したユーザー情報を比較する
-  const isLoginUser = userId === user.student_number.toString();
+  const { data: user } = useUser({ student_number: userId }, router.isReady);
+
+  const { data: loginUser } = useLoginUser();
+  const isLoginUser = userId === loginUser?.user.student_number.toString();
 
   return (
     <div>
       <h1>ユーザー詳細</h1>
-      <div className="user-info">
-        <p>学籍番号: {user.student_number}</p>
-        <p>名前: {user.user_name}</p>
-        <p className="self-introduction">{user.self_introduction}</p>
-        <p>
-          Webサイト: <a href={user.link}>{user.link}</a>
-        </p>
-        {isLoginUser && (
-          <div>
-            <Link href="/user/edit/profile">
-              <a className="edit-link">プロフィールを編集</a>
-            </Link>
-            <Link href="/user/edit/email">
-              <a className="edit-link">登録メールアドレスを編集</a>
-            </Link>
+      {user ? (
+        <div>
+          <div className="user-info">
+            <p>学籍番号: {user.user.student_number}</p>
+            <p>名前: {user.user.user_name}</p>
+            <p className="self-introduction">{user.user.self_introduction}</p>
+            <p>
+              Webサイト: <a href={user.user.link}>{user.user.link}</a>
+            </p>
+            {isLoginUser && (
+              <div>
+                <Link href="/user/edit/profile">
+                  <a className="edit-link">プロフィールを編集</a>
+                </Link>
+                <Link href="/user/edit/email">
+                  <a className="edit-link">登録メールアドレスを編集</a>
+                </Link>
+              </div>
+            )}
           </div>
-        )}
-      </div>
-      <h2>{user.user_name}さんの投稿</h2>
-      <Tabs selectedTabClassName="selected-tab">
-        <TabList className={`tab-list ${scopedTabListClass}`}>
-          <Tab className={tabClass}>募集</Tab>
-          <Tab className={tabClass}>宣伝</Tab>
-          <Tab className={tabClass}>作品</Tab>
-        </TabList>
-        <TabPanel className={tabPanelClass}>
-          <UserOfferProvider studentNumber={userId}>
-            {({ data }) =>
-              data
-                ? data.offers.map((offer) => (
-                    <OfferOverview
-                      key={offer.id}
-                      offer={offer}
-                      editable={isLoginUser}
-                    ></OfferOverview>
-                  ))
-                : 'ロード中'
-            }
-          </UserOfferProvider>
-        </TabPanel>
-        <TabPanel className={tabPanelClass}>
-          <h3>宣伝</h3>
-        </TabPanel>
-        <TabPanel className={tabPanelClass}>
-          <h3>作品</h3>
-        </TabPanel>
-      </Tabs>
+          <h2>{user.user.user_name}さんの投稿</h2>
+          <Tabs selectedTabClassName="selected-tab">
+            <TabList className={`tab-list ${scopedTabListClass}`}>
+              <Tab className={tabClass}>募集</Tab>
+              <Tab className={tabClass}>宣伝</Tab>
+              <Tab className={tabClass}>作品</Tab>
+            </TabList>
+            <TabPanel className={tabPanelClass}>
+              <UserOfferProvider studentNumber={userId}>
+                {({ data }) =>
+                  data
+                    ? data.offers.map((offer) => (
+                        <OfferOverview
+                          key={offer.id}
+                          offer={offer}
+                          editable={isLoginUser}
+                        ></OfferOverview>
+                      ))
+                    : 'ロード中'
+                }
+              </UserOfferProvider>
+            </TabPanel>
+            <TabPanel className={tabPanelClass}>
+              <h3>宣伝</h3>
+            </TabPanel>
+            <TabPanel className={tabPanelClass}>
+              <h3>作品</h3>
+            </TabPanel>
+          </Tabs>
+        </div>
+      ) : (
+        <p>ロード中...</p>
+      )}
       <style jsx>
         {`
           .user-info {

--- a/pages/user/edit/email.tsx
+++ b/pages/user/edit/email.tsx
@@ -4,10 +4,13 @@ import type { ReactElement } from 'react';
 import Modal from 'react-modal';
 import Layout from '../../../components/layouts/Layout';
 import { useEmailForm } from '../../../hooks/forms/useEmailForm';
+import { useLoginUser } from '../../../hooks/requests/auth';
 import { useEditEmail } from '../../../hooks/requests/profile';
-import { user } from '../../../mocks/handlers/auth';
 
 function EditEmailPage() {
+  const { data } = useLoginUser();
+  const user = data?.user;
+
   const [showModal, setShowModal] = useState(false);
   const {
     register,
@@ -29,11 +32,11 @@ function EditEmailPage() {
   });
   const handleCancel = () => {
     if (confirm('入力内容を破棄しますか?')) {
-      router.push(`/user/${user.student_number}`);
+      router.push(`/user/${user?.student_number}`);
     }
   };
   const handleDone = () => {
-    router.push(`/user/${user.student_number}`);
+    router.push(`/user/${user?.student_number}`);
   };
 
   return (

--- a/pages/user/edit/profile.tsx
+++ b/pages/user/edit/profile.tsx
@@ -2,10 +2,13 @@ import { useRouter } from 'next/router';
 import type { ReactElement } from 'react';
 import Layout from '../../../components/layouts/Layout';
 import { useProfileForm } from '../../../hooks/forms/useProfileForm';
+import { useLoginUser } from '../../../hooks/requests/auth';
 import { useEditUser } from '../../../hooks/requests/profile';
-import { user } from '../../../mocks/handlers/auth';
 
 function EditProfilePage() {
+  const { data } = useLoginUser();
+  const user = data?.user;
+
   const {
     register,
     handleSubmit,
@@ -19,14 +22,14 @@ function EditProfilePage() {
   const onSubmit = handleSubmit((data) => {
     mutate(data, {
       onSuccess: () => {
-        router.push(`/user/${user.student_number}`);
+        router.push(`/user/${user?.student_number}`);
       },
     });
   });
 
   const handleCancel = () => {
     if (confirm('入力内容を破棄しますか?')) {
-      router.push(`/user/${user.student_number}`);
+      router.push(`/user/${user?.student_number}`);
     }
   };
 

--- a/public/dropdown.svg
+++ b/public/dropdown.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.355 2.91663L7 8.32486L1.645 2.91663L0 4.58161L7 11.6666L14 4.58161L12.355 2.91663Z" fill="#333333"/>
+</svg>

--- a/public/plus.svg
+++ b/public/plus.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 10.2857H10.2857V18H7.71429V10.2857H0V7.71429H7.71429V0H10.2857V7.71429H18V10.2857Z" fill="white"/>
+</svg>

--- a/utils/configs.ts
+++ b/utils/configs.ts
@@ -1,0 +1,3 @@
+// TODO .envからurlを読み込む
+export const API_HOST =
+  process.env.NODE_ENV === 'production' ? 'http://localhost/api' : '/api';


### PR DESCRIPTION
## 概要
+E展での展示に間に合わすために無理矢理開発を進めました。そのため様々な変更が一つにまとまったクソデカPRに育ちました。このPRにはレビューされていないPR #18 #19 #20 #21 #22 #23 #24 の内容が含まれています。

## やったこと
### ユーザー関連 (#18)
- サイトを初期ロードした段階でクッキーを使ってログイン済みのユーザーを問い合わせる機能を実装しました。
- プロフィールページに表示するユーザーがmock用に定義したダミーユーザーのままだったので、APIから取得するように変更しました。
- 同時にプロフィール編集画面、メールアドレス編集画面の初期表示されるデータもAPIから取得するように変更しました(こちらは #24 の内容です)
### モックサーバーと本番サーバーの切り替え (#19)
- モックサーバーにつながる処理しか書いてなかったので、NODE_ENVの値をみて切り替えるように変更しました。
- それに伴い、確実にmockサーバーとの棲み分けができるように全てのモックサーバーのurlの頭に`\api`をつけました。(#8)
### 募集一覧画面の見た目 (#20)
- 募集画面の全体的なレイアウトを整えました。
- フィルターボタンや投稿するボタンにスタイルがなかったので、雑に見た目を書きました。後でボタンコンポーネントとして抽象化すると思います。
- 募集のタイトル文字しかリンクになっていなかったけど、画像もリンクになってる方が直感的だと思ったので画像もクリックすると詳細ページに飛ぶようにしました。
- ユーザーアイコンを丸くするためにcssで`clip-path`を使っていたのですが、`clip-path`をつけた要素はスタッキングコンテキストが作られるため他の要素より前面に表示されていることがわかりました。`border-radius`で丸くすることで修正しました。今後z-indexの管理を考える必要がありそうです。
#### 応募モーダル (#21)
- 応募モーダルの入力内容を状態管理していなかったので実装しました。react-hook-formで対応できそうな気もするのですが、E展前で考える時間がなかったので`useState`とcontextで実装しました。
- 応募モーダルで応募送信した後に実際にはリクエストを送っていなかったので、応募送信をする機能を実装しました。
- モーダルのページ送りの実装を一部変更しました。詳細は #21 参照。ページ送りの機能は頑張って抽象化したけど、[この辺](https://kentcdodds.com/blog/aha-programming)の意見がごもっともだなって感じたのでまだ抽象化しなくてよかったかも。
- 応募モーダルの見た目を少しだけ改善しました。見た目はさらに改変する予定です。
#### 募集詳細画面の見た目 (#22)
- 募集詳細画面の見た目を雑に綺麗にしました。レスポンシブ対応をしていないので後日対応したいなってお気持ちです。(やるとは言ってない)
#### アイコンが表示されていなかったバグの修正 (#23)
- 募集一覧画面の募集投稿ボタンでプラスアイコンのアセットを追加し忘れていたので追加しました。