### PR TITLE
Fix pagesフォルダ内にテストファイルがあるためプロダクションビルドが落ちてたバグ

### DIFF
--- a/__tests__/AllOffersPage.test.tsx
+++ b/__tests__/AllOffersPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import AllOffersPage from '../board/offers';
+import AllOffersPage from '../pages/board/offers';
 
 const fakeQueryClient = new QueryClient({
   defaultOptions: {

--- a/__tests__/Home.test.tsx
+++ b/__tests__/Home.test.tsx
@@ -1,8 +1,8 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { renderWithClient } from '../../contexts/testUtils';
-import Home from '../index';
+import { renderWithClient } from '../contexts/testUtils';
+import Home from '../pages/index';
 
 // TODO: 後で消す
 describe('Home', () => {


### PR DESCRIPTION
## 概要
pagesフォルダ内にテストファイルがあっため、プロダクションビルドをしたときにdevDependenciesにしか入っていないJestのモジュールを読もうとしてビルドが落ちていました。
ルートディレクトリにテストフォルダを移動することで修正しました。