### PR TITLE
Add 本番環境

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# env file for docker
+.env
+
+# local env files for nextjs
 .env.local
 .env.development.local
 .env.test.local

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,33 @@
+FROM node:16.13.0-alpine3.14 AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./ 
+RUN npm ci
+
+FROM node:16.13.0-alpine3.14 AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED 1
+RUN npm run build
+
+FROM node:16.13.0-alpine3.14 AS runner
+WORKDIR /app
+ENV NODE_ENV production
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+USER nextjs
+
+EXPOSE 2000
+ENV PORT 2000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,92 +1,110 @@
 # GawdiBoard フロントエンド編
-- [gawdiboardとは](#gawdiboardとは)
+
+- [gawdiboard とは](#gawdiboardとは)
 - [開発用環境](#開発用環境)
-  - [nodeのバージョン](#nodeのバージョン)
-  - [nodeがインストールされてる人](#nodeがインストールされてる人)
-  - [nodeがインストールできないorしたくない人](#nodeがインストールできないorしたくない人)
+  - [node のバージョン](#nodeのバージョン)
+  - [node がインストールされてる人](#nodeがインストールされてる人)
+  - [node がインストールできない or したくない人](#nodeがインストールできないorしたくない人)
 - [本番用環境](#本番用環境)
 
-## gawdiboardとは
-GawdiBoard(カウディーボード)はECC コンピュータ専門学校専用の掲示板サイトです。
+## gawdiboard とは
+
+GawdiBoard(カウディーボード)は ECC コンピュータ専門学校専用の掲示板サイトです。
 
 ## 開発用環境
-### nodeのバージョン
-nodeのバージョンは16以上を想定してます。
-nodeのバージョンは開発メンバーで揃えるのが理想なので[nvm](https://github.com/nvm-sh/nvm)の利用をお勧めしています。
 
-nvmを使っている人はクローンした後に
+### node のバージョン
+
+node のバージョンは 16 以上を想定してます。
+node のバージョンは開発メンバーで揃えるのが理想なので[nvm](https://github.com/nvm-sh/nvm)の利用をお勧めしています。
+
+nvm を使っている人はクローンした後に
+
 ```bash
 $ nvm use
 ```
-を実行してください。
-nvm以外のバージョン管理ツールは現状サポートしていません。
 
-### nodeがインストールされてる人
+を実行してください。
+nvm 以外のバージョン管理ツールは現状サポートしていません。
+
+### node がインストールされてる人
+
 インストール方法:
+
 ```bash
 $ git clone https://github.com/ecc-proken/GawdiBoard-frontend.git
 $ npm install
 ```
 
 開発サーバーの起動(`localhost:3000`で起動):
+
 ```bash
 $ npm run dev
 ```
 
 プロダクションビルドを試したくなった時:
+
 ```bash
 $ npm run build && npm start
 ```
 
-### nodeがインストールできないorしたくない人
-開発はDockerじゃなくていいかなと思いながら環境構築をしたのですが、どうしてもnodeを入れられない人、事情があってすごく古いバージョンから動かせない人用にDockerの環境を用意しています。
+### node がインストールできない or したくない人
+
+開発は Docker じゃなくていいかなと思いながら環境構築をしたのですが、どうしても node を入れられない人、事情があってすごく古いバージョンから動かせない人用に Docker の環境を用意しています。
 
 使用コンテナ: [node:16.13.0-alpine3.14](https://hub.docker.com/layers/node/library/node/16.13.0-alpine3.14/images/sha256-becdf5729afc47ce2c14015f63cd04086998a79c3a1f5107a60bd5342367365d?context=explore)
 
 インストール方法:
+
 ```bash
 $ git clone https://github.com/ecc-proken/GawdiBoard-frontend.git
 $ docker compose -f docker-compose.development.yml run --rm node npm i
 ```
 
 開発サーバーの起動(`localhost:3000`で起動):
+
 ```bash
 $ docker compose -f docker-compose.development.yml up
 ```
 
 npm install したい時:
+
 ```bash
 $ docker compose -f docker-compose.development.yml run --rm node npm i
 ```
 
 プロダクションビルドを試したくなった時:
+
 ```bash
 $ docker compose -f docker-compose.development.yml run --rm node node_modules/.bin/next build && node_modules/.bin/next start
 ```
 
-#### -fフラグの省略
+#### -f フラグの省略
+
 上のコマンドでは`docker compose`コマンドに`-f`オプションで compose.yml ファイルを指定していますが、環境変数を設定することで毎回ファイル名を指定しなくて良くなります。
 
 環境変数`COMPOSE_FILE`を`docker-compose.development.yml`に設定すると
+
 ```
 $ docker compose up
 ```
+
 だけで開発サーバーが立つようになります。
 
-ちなみに環境変数は`.env`ファイルでも設定できますが、現状の構成だとルートディレクトリにenvファイルを作るとコンテナ内のnext.jsも同じenvファイルを読み込むので、干渉しないように注意してください。
+ちなみに環境変数は`.env`ファイルでも設定できますが、現状の構成だとルートディレクトリに env ファイルを作るとコンテナ内の next.js も同じ env ファイルを読み込むので、干渉しないように注意してください。
 
 ## 本番用環境
-**(まだできてません、後で作ります)**
 
-本番用のDockerを使ってください。
+本番用の Docker を使ってください。
 
-本番サーバー下では凡ミスで開発環境を立ち上げたくないので、`-f`オプションの利用はお勧めしません。
+1. 環境変数`COMPOSE_FILE`を`docker-compose.production.yml`に設定する
+2. .env.local ファイルに`NEXT_PUBLIC_API_HOST={バックエンドapiのurl}/api`を書く
+3. `docker-compose up`を実行する
 
-環境変数`COMPOSE_FILE`を`docker-compose.production.yml`に設定してから
-```bash
-$ docker compose up
-```
-を実行してください。
+### 運用係の人へ
+
+別途お渡ししている本番環境仕様書の「フロントエンド」の項目を確認の上でデプロイ作業をしてください。
 
 ## 備考
+
 このプロジェクトは[`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app)を使って作られました。

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  app:
+    build:
+      context: ./
+      dockerfile: Dockerfile.production
+    container_name: 'gawdiboard-front'
+    ports:
+      - '2000:2000'

--- a/utils/configs.ts
+++ b/utils/configs.ts
@@ -1,3 +1,4 @@
-// TODO .envからurlを読み込む
 export const API_HOST =
-  process.env.NODE_ENV === 'production' ? 'http://localhost/api' : '/api';
+  process.env.NODE_ENV === 'production'
+    ? process.env.NEXT_PUBLIC_API_HOST
+    : '/api';


### PR DESCRIPTION
## 概要
本番で使うDocker環境を整備しました。

## やったこと
- 本番で使うDockerfileとcomposeファイルを書きました。
- バックエンドのAPIのurlをソースコードにベタ書きしていたので.env.localから読み取るようにしました。
- docker-composeで-fフラグをつけなくていいように`.env`ファイルで`COMPOSE_FILE`を設定すると楽かなと思ったので`.env`をgitignoreに追加しました。
- READMEに本番環境に関する説明を書きました。

## メモ
- 将来CI/CDサービスでdockerイメージをビルドして、イメージだけを本番環境で拾うようにする流れを組めるように(多分組まないだろうけど)、最終的なイメージのサイズがなるべく小さくなる[マルチステージビルド](https://matsuand.github.io/docs.docker.jp.onthefly/develop/develop-images/multistage-build/)を使ってみました。
- Nextのv12以降で[node_modulesの全ファイルをデプロイしなくてもいい機能](https://nextjs.org/docs/advanced-features/output-file-tracing#caveats)が追加されてますが、まだ実験的機能だったので使っていません。
- docker-composeのcomposeファイルの指定のために.envを使っていますがNextもビルド時にこのenvファイルを読んでしまうので注意が必要です。
- docker-composeの方で使うので.envをgitignoreしていますが、Next的には.env.local系をgitignoreして.envはgitignoreしない想定で作られてると聞いたことがある。。今からフォルダ構造を変えるのが面倒なので妥協でそのままにしてます。